### PR TITLE
Erreurs d'update établissement lors d'historisation

### DIFF
--- a/application/services/Etablissement.php
+++ b/application/services/Etablissement.php
@@ -567,14 +567,15 @@ class Service_Etablissement implements Service_Interface_Etablissement
             else {
                 $information_a_la_date_donnee = $DB_informations->fetchRow("ID_ETABLISSEMENT = '" .  $id_etablissement . "' AND DATE_ETABLISSEMENTINFORMATIONS = '" . $date . "'");
 
+                $DB_etablissements_lies->delete("ID_ETABLISSEMENT = " . $etablissement->ID_ETABLISSEMENT);
+                $DB_adresse->delete("ID_ETABLISSEMENT = " . $etablissement->ID_ETABLISSEMENT);
+                
                 if($information_a_la_date_donnee != null) {
                     $informations = $information_a_la_date_donnee;
                     $DB_plans->delete("ID_ETABLISSEMENTINFORMATIONS = " . $informations->ID_ETABLISSEMENTINFORMATIONS);
                     $DB_rubrique->delete("ID_ETABLISSEMENTINFORMATIONS = " . $informations->ID_ETABLISSEMENTINFORMATIONS);
                     $DB_types_activites_secondaires->delete("ID_ETABLISSEMENTINFORMATIONS = " . $informations->ID_ETABLISSEMENTINFORMATIONS);
-                    $DB_preventionniste->delete("ID_ETABLISSEMENTINFORMATIONS = " . $informations->ID_ETABLISSEMENTINFORMATIONS);
-                    $DB_etablissements_lies->delete("ID_ETABLISSEMENT = " . $etablissement->ID_ETABLISSEMENT);
-                    $DB_adresse->delete("ID_ETABLISSEMENT = " . $etablissement->ID_ETABLISSEMENT);
+                    $DB_preventionniste->delete("ID_ETABLISSEMENTINFORMATIONS = " . $informations->ID_ETABLISSEMENTINFORMATIONS);                    
                 }
                 else {
                     $informations = $DB_informations->createRow(array('DATE_ETABLISSEMENTINFORMATIONS' => $date));


### PR DESCRIPTION
Lorsqu'on historise (met à jour) un établissement, les enregistrements des tables liées à ETABLISSEMENT ne sont pas supprimées comme pour l'update classique :
- Duplicate key on update lorsqu'on historise un établissement avec un fils
- Duplication des adresses lorsqu'on historise un établissement

Correction de ce problème en généralisant la suppression des liens sur établissements fils et adresse.

Reste un problème sur la MAJ des activités secondaires.
