### PR TITLE
Correction sur le bloc "dossiers suivi du préventionniste" qui ne doivent pas être verrouillés pour disparaître

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Corrections :
 * Correction d'un erreur javascript sans incidence sur la double inclusion de dossiergeneral.js
 * Correction de l'utilisation de la variable PREVARISC_REAL_DATA_PATH sous Windows Serveur
 * Correction d'un problème sur la recherche de courriers sans établissements rattachés
+* Correction sur le bloc "dossiers suivi du préventionniste" qui ne doivent pas forcément être verrouillés pour disparaître de son bloc
 
 ## 2.3
 

--- a/application/services/Dashboard.php
+++ b/application/services/Dashboard.php
@@ -202,7 +202,6 @@ class Service_Dashboard
         $search = new Model_DbTable_Search;
         $search->setItem("dossier");
         $search->setCriteria("utilisateur.ID_UTILISATEUR", $id_user);
-        $search->setCriteria("d.VERROU_DOSSIER", 0);
         $search->setCriteria("d.AVIS_DOSSIER IS NULL");
         
         // on retire les dossiers périodiques de la liste, car cela ferait trop de dossiers


### PR DESCRIPTION
Tout est dans le titre
