### PR TITLE
Deplacement date commission dossier KO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Corrections :
 * Correction d'un erreur javascript sans incidence sur la double inclusion de dossiergeneral.js
 * Correction de l'utilisation de la variable PREVARISC_REAL_DATA_PATH sous Windows Serveur
 * Correction d'un problème sur la recherche de courriers sans établissements rattachés
+* Correction sur le bloc "dossiers suivi du préventionniste" qui ne doivent pas forcément être verrouillés pour disparaître de son bloc
 
 ## 2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Corrections :
 * Correction de l'utilisation de la variable PREVARISC_REAL_DATA_PATH sous Windows Serveur
 * Correction d'un problème sur la recherche de courriers sans établissements rattachés
 * Correction sur le bloc "dossiers suivi du préventionniste" qui ne doivent pas forcément être verrouillés pour disparaître de son bloc
+* Correction importante lors du déplacement/modification d'une date de commission/visite sur la calendrier, non répercuté sur la liste des dossiers d'un établissement
 
 ## 2.3
 

--- a/application/controllers/CalendrierDesCommissionsController.php
+++ b/application/controllers/CalendrierDesCommissionsController.php
@@ -536,8 +536,8 @@ class CalendrierDesCommissionsController extends Zend_Controller_Action
                 break;
                 case "valid_dateCom":
                     //VALIDATION Lorsque l'on modifie la date
-                        $HeureD = new Zend_Date($this->_getParam('hd'),'HH:mm','en');
-                        $HeureF = new Zend_Date($this->_getParam('hf'),'HH:mm','en');
+                    $HeureD = new Zend_Date($this->_getParam('hd'),'HH:mm','en');
+                    $HeureF = new Zend_Date($this->_getParam('hf'),'HH:mm','en');
                     $date = new Zend_Date($this->_getParam('date'),Zend_Date::DATES,'fr');
 
                     $dbDateCommission = new Model_DbTable_DateCommission;
@@ -546,6 +546,9 @@ class CalendrierDesCommissionsController extends Zend_Controller_Action
                     $updateDateComm->HEUREFIN_COMMISSION = $HeureF->get('HH:mm');
                     $updateDateComm->DATE_COMMISSION = $date->get(Zend_Date::YEAR."-".Zend_Date::MONTH."-".Zend_Date::DAY);
                     $updateDateComm->save();
+                    
+                    $dbDateCommission->updateDependingDossierDates($updateDateComm);
+                    
                     $this->view->updateDateComm = $updateDateComm;
                     $this->view->first = $this->_getParam('first');
                 break;
@@ -741,6 +744,7 @@ class CalendrierDesCommissionsController extends Zend_Controller_Action
 
     public function deplacecommissiondateAction()
     {
+            
         try {
             $date = new Zend_Date($_POST['debut'],Zend_Date::DATES,'en');
 
@@ -756,6 +760,9 @@ class CalendrierDesCommissionsController extends Zend_Controller_Action
                 $commUpdate->HEUREFIN_COMMISSION = $HeureF->get('HH:mm');
             }
             $commUpdate->save();
+
+            $dbDateCommission->updateDependingDossierDates($commUpdate);
+            
             $this->_helper->flashMessenger(array(
                 'context' => 'success',
                 'title' => 'L\'événement a bien été déplacé',

--- a/application/models/DbTable/DateCommission.php
+++ b/application/models/DbTable/DateCommission.php
@@ -157,5 +157,32 @@
 				 
 			return $this->getAdapter()->fetchAll($select);
 		}
+                
+        public function updateDependingDossierDates($datecommission)
+        {
+            $dbAffectDossier = new Model_DbTable_DossierAffectation();
+            $dbDossier = new Model_DbTable_Dossier();
+            
+            // on récupère les dossiers liés à la commission
+            $dossiersAffecte = $dbAffectDossier->fetchAll('ID_DATECOMMISSION_AFFECT = '.$datecommission->ID_DATECOMMISSION);
+            $dossiersAffecteIds = array();
+            foreach($dossiersAffecte as $dossierAffecte) {
+                $dossiersAffecteIds[] = $dossierAffecte['ID_DOSSIER_AFFECT'];
+            }
+            
+            // si des dossiers sont liés, en fonction du type,
+            // on update les dates en text dans les différents fields du dossiers pour 
+            // des cohérences de données
+            if ($dossiersAffecteIds) {
+                if (in_array($datecommission->ID_COMMISSIONTYPEEVENEMENT, array(1))) {
+                    //COMMISSION EN SALLE
+                    $dbDossier->update(array('DATECOMM_DOSSIER' => $datecommission->DATE_COMMISSION), 'ID_DOSSIER IN('.implode(',', $dossiersAffecteIds).')');
+                }
+                else if (in_array($datecommission->ID_COMMISSIONTYPEEVENEMENT, array(2,3))) {
+                    //VISITE OU GROUPE DE VISITE
+                    $dbDossier->update(array('DATEVISITE_DOSSIER' => $datecommission->DATE_COMMISSION), 'ID_DOSSIER IN ('.implode(',', $dossiersAffecteIds).')');
+                }
+            }
+        }
 
     }

--- a/application/services/Dashboard.php
+++ b/application/services/Dashboard.php
@@ -202,7 +202,6 @@ class Service_Dashboard
         $search = new Model_DbTable_Search;
         $search->setItem("dossier");
         $search->setCriteria("utilisateur.ID_UTILISATEUR", $id_user);
-        $search->setCriteria("d.VERROU_DOSSIER", 0);
         $search->setCriteria("d.AVIS_DOSSIER IS NULL");
         
         // on retire les dossiers périodiques de la liste, car cela ferait trop de dossiers


### PR DESCRIPTION
Correction importante lors du déplacement/modification d'une date de commission/visite sur la calendrier, non répercuté sur la liste des dossiers d'un établissement

Du au problème des dates dupliquées au niveau des champs "DATEVISITE_DOSSIER" et "DATECOM_DOSSIER"
