### PR TITLE
Bloc dossiers suivis restrictions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ Corrections :
 * Correction sur le bloc "dossiers suivi du préventionniste" qui ne doivent pas forcément être verrouillés pour disparaître de son bloc
 * Correction importante lors du déplacement/modification d'une date de commission/visite sur la calendrier, non répercuté sur la liste des dossiers d'un établissement
 * Correction de la possibilité d'ajouter une PJ sur un dossier même verrouillé
+* Correction du bloc "dossiers suivi du préventionniste" qui affichait trop de dossiers avec le retrait du verrouillage. On n'affiche plus que les courriers et études.
+* Correction générale sur les blocs du dashboard : les dossiers sont enregistrés avec un avis commission = 0 !!! et non null
 
 ## 2.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.4 
+## 2.4
 
 Evolutions :
 * Mise à jour de packery en 1.3.0
@@ -56,6 +56,8 @@ Corrections :
 * Correction importante lors du déplacement/modification d'une date de commission/visite sur la calendrier, non répercuté sur la liste des dossiers d'un établissement
 * Correction de la possibilité d'ajouter une PJ sur un dossier même verrouillé
 * Augmentation de la limite du nombre d'utilisateurs connectés affichés dans le BO (avec +300 maires, on ne voit pas tous les utilisateurs)
+* Correction du bloc "dossiers suivi du préventionniste" qui affichait trop de dossiers avec le retrait du verrouillage. On n'affiche plus que les courriers et études.
+* Correction générale sur les blocs du dashboard : les dossiers sont enregistrés avec un avis commission = 0 !!! et non null
 
 ## 2.3
 

--- a/application/models/DbTable/Dossier.php
+++ b/application/models/DbTable/Dossier.php
@@ -302,12 +302,14 @@
                          ->group("d.ID_DOSSIER")
                          ->where("DATEDIFF(CURDATE(), datecommission.DATE_COMMISSION) >= ".((int) $sinceDays))
                          ->where("DATEDIFF(CURDATE(), datecommission.DATE_COMMISSION) <= ".((int) $untilDays))
-                         ->where("d.AVIS_DOSSIER_COMMISSION IS NULL");
+                         ->where("d.AVIS_DOSSIER_COMMISSION IS NULL or d.AVIS_DOSSIER_COMMISSION = 0")
+                         ->order("datecommission.DATE_COMMISSION desc");
             
             if (count($ids) > 0) {
-                $select->where("datecommission.COMMISSION_CONCERNE", $ids);
+                $select->where("datecommission.COMMISSION_CONCERNE IN (".implode(",", $ids).")");
             }
-                 
+            
+            
             return $this->getAdapter()->fetchAll($select);
         }
         

--- a/application/services/Dashboard.php
+++ b/application/services/Dashboard.php
@@ -196,17 +196,20 @@ class Service_Dashboard
     public function getDossiersSuivisSansAvis($user) {
         
         $dossiers = array();
+        
         $id_user = $user['ID_UTILISATEUR'];
         
         // Dossiers suivis
         $search = new Model_DbTable_Search;
         $search->setItem("dossier");
         $search->setCriteria("utilisateur.ID_UTILISATEUR", $id_user);
-        $search->setCriteria("d.AVIS_DOSSIER IS NULL");
         
-        // on retire les dossiers périodiques de la liste, car cela ferait trop de dossiers
-        // on ne garde que les études
-        $search->setCriteria("dossiernature.ID_NATURE NOT IN (".implode(',', array(21, 26)).")");
+        $conditionEtudesSansAvis = "d.AVIS_DOSSIER IS NULL AND (d.AVIS_DOSSIER_COMMISSION IS NULL OR d.AVIS_DOSSIER_COMMISSION = 0) AND d.TYPE_DOSSIER = 1";
+        $conditionCourriersSansReponse = "d.DATEREP_DOSSIER IS NULL AND d.TYPE_DOSSIER = 5";
+        
+        $search->setCriteria("($conditionEtudesSansAvis) OR ($conditionCourriersSansReponse)");        
+        
+        $search->order('d.DATEINSERT_DOSSIER desc');
         
         $dossiers = $search->run(false, null, false)->toArray();
         


### PR DESCRIPTION
- Correction du bloc "dossiers suivi du préventionniste" qui affichait trop de dossiers avec le retrait du verrouillage. On n'affiche plus que les courriers et études.
- Correction générale sur les blocs du dashboard : les dossiers sont enregistrés avec un avis commission = 0 !!! et non null
