### PR TITLE
Correction sur la génération des ODJ et convocation balise nomPereEtab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ Corrections :
 * Correction du bloc "dossiers suivi du préventionniste" qui affichait trop de dossiers avec le retrait du verrouillage. On n'affiche plus que les courriers et études.
 * Correction générale sur les blocs du dashboard : les dossiers sont enregistrés avec un avis commission = 0 !!! et non null
 * Correction sur les convocations pour les maires : partie dossiersInfos KO
+* Correction de l'avis toujours indisponible lorsque le dossier est créé, et conséquence sur la possibilité de différer l'avis
+* Correction sur la génération des ODJ et convocation : la balise nomPereEtab reprenait le nom du précédent établissement père
 
 ## 2.3
 

--- a/application/views/scripts/calendrier-des-commissions/generationconvoc.phtml
+++ b/application/views/scripts/calendrier-des-commissions/generationconvoc.phtml
@@ -209,9 +209,11 @@ function savePj($dateCommId, $membreNom){
 
 function retrieveInfoDossier($segment, $dossierInfos) {
     setVars($segment, 'nomEtab',$dossierInfos['infosEtab']['informations']["LIBELLE_ETABLISSEMENTINFORMATIONS"]);
+    $nomPere = "";
     if(isset($dossierInfos['infosEtab']['parents'][0]["LIBELLE_ETABLISSEMENTINFORMATIONS"])) {
-        setVars($segment, 'nomPereEtab', $dossierInfos['infosEtab']['parents'][0]["LIBELLE_ETABLISSEMENTINFORMATIONS"]);
+        $nomPere = $dossierInfos['infosEtab']['parents'][0]["LIBELLE_ETABLISSEMENTINFORMATIONS"];
     }
+    setVars($segment, 'nomPereEtab', $nomPere);
     setVars($segment, 'idDossier', $dossierInfos["ID_DOSSIER"]);
     setVars($segment, 'numWinPrev', $dossierInfos['infosEtab']['general']['NUMEROID_ETABLISSEMENT']);
     setVars($segment, 'mailEtab', $dossierInfos['infosEtab']['general']["COURRIEL_ETABLISSEMENT"]);
@@ -252,9 +254,11 @@ function retrieveInfoDossier($segment, $dossierInfos) {
 
     $listePreventioniste = array();
     $listeTelPreventioniste = array();
-    foreach($dossierInfos["preventionnistes"] as $va => $preventioniste){
-	$listePreventioniste[] = $preventioniste['GRADE_UTILISATEURINFORMATIONS']. " " .$preventioniste['NOM_UTILISATEURINFORMATIONS']. " ".$preventioniste['PRENOM_UTILISATEURINFORMATIONS'];
-        $listeTelPreventioniste[] = $preventioniste['TELFIXE_UTILISATEURINFORMATIONS'];
+    if (isset($dossierInfos["preventionnistes"])) {
+        foreach($dossierInfos["preventionnistes"] as $va => $preventioniste){
+            $listePreventioniste[] = $preventioniste['GRADE_UTILISATEURINFORMATIONS']. " " .$preventioniste['NOM_UTILISATEURINFORMATIONS']. " ".$preventioniste['PRENOM_UTILISATEURINFORMATIONS'];
+            $listeTelPreventioniste[] = $preventioniste['TELFIXE_UTILISATEURINFORMATIONS'];
+        }
     }
     setVars($segment, 'preventionnistes', implode(', ', $listePreventioniste));
     setVars($segment, 'listeTelPreventioniste', implode(', ', $listeTelPreventioniste));

--- a/application/views/scripts/calendrier-des-commissions/generationodj.phtml
+++ b/application/views/scripts/calendrier-des-commissions/generationodj.phtml
@@ -152,6 +152,12 @@ function retrieveInfoDoss($segment, $dossierInfos) {
     if(isset($dossierInfos['infosEtab']['parents'][0]) && $dossierInfos['infosEtab']['parents'][0]["LIBELLE_ETABLISSEMENTINFORMATIONS"] != NULL) {
         addChamp($segment->infosDoss, 'nomPereEtab', $dossierInfos['infosEtab']['parents'][0]["LIBELLE_ETABLISSEMENTINFORMATIONS"]);
     }
+    $nomPere = "";
+    if(isset($dossierInfos['infosEtab']['parents'][0]) && $dossierInfos['infosEtab']['parents'][0]["LIBELLE_ETABLISSEMENTINFORMATIONS"] != NULL) {
+        $nomPere = $dossierInfos['infosEtab']['parents'][0]["LIBELLE_ETABLISSEMENTINFORMATIONS"];
+    }
+    addChamp($segment->infosDoss, 'nomPereEtab', $nomPere);
+    
     addChamp($segment->infosDoss, 'natureDossier', $dossierInfos["LIBELLE_DOSSIERNATURE"]);
     addChamp($segment->infosDoss, 'objetDossier', $dossierInfos["OBJET_DOSSIER"]);
     $commune = "";
@@ -190,9 +196,11 @@ function retrieveInfoDoss($segment, $dossierInfos) {
     addChamp($segment->infosDoss, 'typeDossierCourt', $typeDossierCourt);
     $listePreventioniste = array();
     $listeTelPreventioniste = array();
-    foreach($dossierInfos["preventionnistes"] as $va => $preventioniste){
-	$listePreventioniste[] = $preventioniste['GRADE_UTILISATEURINFORMATIONS']. " ".$preventioniste['NOM_UTILISATEURINFORMATIONS']. " ".$preventioniste['PRENOM_UTILISATEURINFORMATIONS'];
-        $listeTelPreventioniste[] = $preventioniste['TELFIXE_UTILISATEURINFORMATIONS'];
+    if (isset($dossierInfos["preventionnistes"])) {
+        foreach($dossierInfos["preventionnistes"] as $va => $preventioniste){
+            $listePreventioniste[] = $preventioniste['GRADE_UTILISATEURINFORMATIONS']. " ".$preventioniste['NOM_UTILISATEURINFORMATIONS']. " ".$preventioniste['PRENOM_UTILISATEURINFORMATIONS'];
+            $listeTelPreventioniste[] = $preventioniste['TELFIXE_UTILISATEURINFORMATIONS'];
+        }
     }
     addChamp($segment->infosDoss, 'preventionnistes', implode(', ', $listePreventioniste));
     addChamp($segment->infosDoss, 'listeTelPreventioniste', implode(', ', $listeTelPreventioniste)); 


### PR DESCRIPTION
Correction sur la génération des ODJ et convocation : la balise nomPereEtab reprenait le nom du précédent établissement père
