### PR TITLE
Correction de l'objet du dossier qui restait même après avoir changé de nature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,12 @@ Corrections :
 * Correction sur les convocations pour les maires : partie dossiersInfos KO
 * Correction de l'avis toujours indisponible lorsque le dossier est créé, et conséquence sur la possibilité de différer l'avis
 * Correction sur la génération des ODJ et convocation : la balise nomPereEtab reprenait le nom du précédent établissement père
+* Correction du préventionniste sans civilite qui n'apparaît pas sur les dossiers
+* Correction de la non apparition du type EM, EP, GEEM sur les activités des membres de commission
+* Correction de la taille des rubriques ICPE pour les petits écrans (supperposition gênante)
+* Correction des simples quotes non gérées sur les coordonnées de groupements de communes et maires de communes
+* Correction de la disparition du groupement de commune de la liste après enregistrement
+* Correction de l'objet du dossier qui restait même après avoir changé de nature
 
 ## 2.3
 

--- a/application/controllers/DossierController.php
+++ b/application/controllers/DossierController.php
@@ -873,7 +873,8 @@ class DossierController extends Zend_Controller_Action
                     if ('AVIS_DOSSIER' == $libelle && 0 == $value) {
                         $value = null;
                     }
-
+                   //echo $this->_getParam('HORSDELAI_DOSSIER');
+                    
                     if ('' == $value) {
                         $value = null;
                     }
@@ -910,6 +911,10 @@ class DossierController extends Zend_Controller_Action
                 $nouveauDossier->CNE_DOSSIER = 0;
             } else {
                 $nouveauDossier->CNE_DOSSIER = 1;
+            }
+            
+            if (!in_array('OBJET', $this->listeChamps[$this->_getParam('selectNature')])) {
+                $nouveauDossier->OBJET_DOSSIER = null;
             }
 
             if (null != $this->_getParam('servInst')) {


### PR DESCRIPTION
Lorsqu'on réutilise un dossier en changeant sa nature (suppression impossible), l'objet du dossier restait, ce qui peut générer des questions / erreurs sur des dossiers qui n'ont pas d'objet (ex groupe de visite périodique).
