### PR TITLE
Correction de la liaison d'un dossier à un établissement qui ne répercutait pas son avis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,13 @@ Corrections :
 * Correction sur les convocations pour les maires : partie dossiersInfos KO
 * Correction de l'avis toujours indisponible lorsque le dossier est créé, et conséquence sur la possibilité de différer l'avis
 * Correction sur la génération des ODJ et convocation : la balise nomPereEtab reprenait le nom du précédent établissement père
+* Correction du préventionniste sans civilite qui n'apparaît pas sur les dossiers
+* Correction de la non apparition du type EM, EP, GEEM sur les activités des membres de commission
+* Correction de la taille des rubriques ICPE pour les petits écrans (supperposition gênante)
+* Correction des simples quotes non gérées sur les coordonnées de groupements de communes et maires de communes
+* Correction de la disparition du groupement de commune de la liste après enregistrement
+* Correction de l'objet du dossier qui restait même après avoir changé de nature
+* Correction de la liaison d'un dossier à un établissement qui ne répercutait pas son avis
 
 ## 2.3
 


### PR DESCRIPTION
Correction de la liaison d'un dossier à un établissement qui ne répercutait pas son avis alors qu'il le fait dès qu'on fait un modifier / sauvegarder sur le dossier.
Aussi, correction sur la comparaison entre la date du nouveau et de l'ancien dossier : les 2 dates comparées n'étaient pas les mêmes (problème de logique / algorithmie).
