### PR TITLE
Cache nosql mysql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Evolutions :
 * Ajout d'un cache APC sur les métadonnées de l'ORM hors DEV
 * Auto-complétion des villes à partir de 2 caractères pour les communes à 2 caractères
 * Ajout de balises dans l'ODJ
+* Ajout du support du cache nosql mysql
 
 Corrections :
 * Impossibilité de créer des dossiers en décembre : mauvais validateur de date

--- a/application/Bootstrap.php
+++ b/application/Bootstrap.php
@@ -23,29 +23,7 @@ class Bootstrap extends Zend_Application_Bootstrap_Bootstrap
 
         return parent::run();
     }
-
-    /**
-     * Initialisation du cache APC
-     */
-    protected function _initCache()
-    {
-        return Zend_Cache::factory('Core', 'APC', array(
-            'lifetime' => getenv('PREVARISC_CACHE_LIFETIME'),
-            'cache_id_prefix' => 'prevarisc'
-        ));
-    }
-
-    /**
-     * Initialisation du cache APC spécial recherches
-     */
-    protected function _initCacheSearch()
-    {
-        return Zend_Cache::factory('Core', 'APC', array(
-            'lifetime' => getenv('PREVARISC_CACHE_LIFETIME'),
-            'cache_id_prefix' => 'prevarisc_search'
-        ));
-    }
-
+    
     /**
      * Initialisation de l'auto-loader
      */
@@ -54,11 +32,71 @@ class Bootstrap extends Zend_Application_Bootstrap_Bootstrap
         $autoloader = Zend_Loader_Autoloader::getInstance();
 
         $autoloader_application = new Zend_Application_Module_Autoloader(array('basePath' => APPLICATION_PATH, 'namespace'  => null));
-
+        
+        $autoloader_application->addResourceType('cache', 'cache/', 'Cache');
+        
         $autoloader->pushAutoloader($autoloader_application);
 
         return $autoloader;
     }
+    
+    /**
+     * Initialisation d'un cache standard
+     * @param array $frontendOptions surcharge des options de configuration du front
+     * @param array $backendOptions surcharge des options de configuration du back
+     * @return Cache une instance de cache
+     */
+    protected function getCache(array $frontendOptions = array(), array $backendOptions = array()) {
+        
+        $options = $this->getOption('cache');
+        
+        return Zend_Cache::factory(
+                // front adapter
+                'Core',
+                // back adapter
+                $options['adapter'], 
+                // frontend options
+                array_merge(array(
+                    'caching'  => $options['enabled'],
+                    'lifetime' => $options['lifetime'],
+                    'cache_id_prefix' => 'prevarisc_',
+                    'write_control' => $options['write_control'],
+                ), $frontendOptions),
+                // backend options
+                array_merge(array(
+                    'servers' => array(
+                        array(
+                            'host' => $options['host'], 
+                            'port' => $options['port'],
+                        ),
+                    ),
+                    'compression' => $options['compression'],
+                ), $backendOptions),
+                // use a custom name for front
+                false,
+                // use a custom name for back
+                $options['customAdapter'],
+                // use application's autoload if an adapter is not loaded
+                true);
+    }
+
+    /**
+     * Initialisation du cache objet de l'application
+     */
+    protected function _initCache()
+    {
+        return $this->getCache();
+    }
+
+    /**
+     * Initialisation du cache spécial recherches
+     */
+    protected function _initCacheSearch()
+    {
+        return $this->getCache();
+    }
+
+    
 
     /**
      * Initialisation de la vue

--- a/application/cache/MySQLMemcached.php
+++ b/application/cache/MySQLMemcached.php
@@ -1,0 +1,64 @@
+<?php
+
+/**
+ * @see Zend_Cache_Backend_Memcached
+ */
+class Cache_MySQLMemcached extends Zend_Cache_Backend_Memcached
+{
+
+    /**
+     * Overide default memcache object's connexion for mysql memcache implementation
+     * Get method returns serialized objects instead of serialized
+     */
+    public function __construct(array $options = array())
+    {
+        if (!extension_loaded('memcache')) {
+            Zend_Cache::throwException('The memcache extension must be loaded for using this backend !');
+        }
+        parent::__construct($options);
+        if (isset($this->_options['servers'])) {
+            $value= $this->_options['servers'];
+            if (isset($value['host'])) {
+                // in this case, $value seems to be a simple associative array (one server only)
+                $value = array(0 => $value); // let's transform it into a classical array of associative arrays
+            }
+            $this->setOption('servers', $value);
+        }
+        $this->_memcache = new Cache_UnserializedMemcache;
+        foreach ($this->_options['servers'] as $server) {
+            if (!array_key_exists('port', $server)) {
+                $server['port'] = self::DEFAULT_PORT;
+            }
+            if (!array_key_exists('persistent', $server)) {
+                $server['persistent'] = self::DEFAULT_PERSISTENT;
+            }
+            if (!array_key_exists('weight', $server)) {
+                $server['weight'] = self::DEFAULT_WEIGHT;
+            }
+            if (!array_key_exists('timeout', $server)) {
+                $server['timeout'] = self::DEFAULT_TIMEOUT;
+            }
+            if (!array_key_exists('retry_interval', $server)) {
+                $server['retry_interval'] = self::DEFAULT_RETRY_INTERVAL;
+            }
+            if (!array_key_exists('status', $server)) {
+                $server['status'] = self::DEFAULT_STATUS;
+            }
+            if (!array_key_exists('failure_callback', $server)) {
+                $server['failure_callback'] = self::DEFAULT_FAILURE_CALLBACK;
+            }
+            if ($this->_options['compatibility']) {
+                // No status for compatibility mode (#ZF-5887)
+                $this->_memcache->addServer($server['host'], $server['port'], $server['persistent'],
+                                        $server['weight'], $server['timeout'],
+                                        $server['retry_interval']);
+            } else {
+                $this->_memcache->addServer($server['host'], $server['port'], $server['persistent'],
+                                        $server['weight'], $server['timeout'],
+                                        $server['retry_interval'],
+                                        $server['status'], $server['failure_callback']);
+            }
+        }
+    }
+
+}

--- a/application/cache/UnserializedMemcache.php
+++ b/application/cache/UnserializedMemcache.php
@@ -1,0 +1,15 @@
+<?php
+
+class Cache_UnserializedMemcache extends Memcache {
+    
+    protected function fixReturnedContent($data) {
+        if ($data === false) {
+            return false;
+        }
+        return is_string($data) ? unserialize($data) : $data;
+    }
+    
+    public function get($key, $flags = null) {
+        return $this->fixReturnedContent(parent::get($key, $flags));
+    }
+}

--- a/application/controllers/AdminController.php
+++ b/application/controllers/AdminController.php
@@ -4,16 +4,23 @@ class AdminController extends Zend_Controller_Action
 {
     public function indexAction()
     {
+        $cache_config = $this->getInvokeArg('bootstrap')->getOption('cache');
+        
         $this->_helper->layout->setLayout('menu_admin');
 
         $this->view->key_ign = getenv('PREVARISC_PLUGIN_IGNKEY');
         $this->view->key_googlemap = getenv('PREVARISC_PLUGIN_GOOGLEMAPKEY');
         $this->view->ldap_enabled = getenv('PREVARISC_LDAP_ENABLED');
         $this->view->dbname = getenv('PREVARISC_DB_DBNAME');
-        $this->view->db_url = getenv('PREVARISC_DB_HOST');
+        $this->view->db_url = getenv('PREVARISC_DB_HOST').(getenv('PREVARISC_DB_PORT') ? ':'.getenv('PREVARISC_DB_PORT') : '');
         $this->view->api_enabled = getenv('PREVARISC_SECURITY_KEY') != "";
         $this->view->proxy_enabled = getenv('PREVARISC_PROXY_ENABLED');
         $this->view->third_party_plugins = implode(', ', explode(';', getenv('PREVARISC_THIRDPARTY_PLUGINS')));
+        
+        $this->view->cache_adapter = $cache_config['adapter'];
+        $this->view->cache_url = $cache_config['host']. ($cache_config['port'] ? ':'.$cache_config['port'] : '');
+        $this->view->cache_lifetime = $cache_config['lifetime'];
+        $this->view->cache_enabled = $cache_config['enabled'];
 
         $service_search = new Service_Search;
         $users = $service_search->users(null, null, null, true, 1000)['results'];

--- a/application/views/scripts/admin/index.phtml
+++ b/application/views/scripts/admin/index.phtml
@@ -28,6 +28,17 @@
                 <dd>
                 <p><em><?php echo $this->dbname ?></em> sur <em><?php echo $this->db_url ?></em></p>
                 </dd>
+                
+                <dt>Cache</dt>
+                <dd>
+                <?php if ($this->cache_enabled): ?>
+                    <p><?php echo $this->cache_adapter ?></p>
+                    <p><?php echo $this->cache_url ?></p>
+                    <p><?php echo $this->cache_lifetime ?> sec de durée de vie</p>
+                <?php else: ?>
+                    <p>Désactivé</p>
+                <?php endif ?>
+                </dd>
 
                 <dt>HTTP API</dt>
                 <dd>

--- a/docs/documentation_installation.md
+++ b/docs/documentation_installation.md
@@ -61,7 +61,10 @@ PREVARISC_DB_HOST | Adresse de la base de données | Adresse IP
 PREVARISC_DB_USERNAME | Nom d'utilisateur à utiliser lors de la connexion à la base de données | Chaine de caractères
 PREVARISC_DB_PASSWORD | Mot de passe de connexion à la base de données | Chaine de caractères
 PREVARISC_DB_DBNAME | Nom de la base de données | Chaine de caractères
-PREVARISC_CACHE_LIFETIME | Durée de vie du cache APC | Valeur numérique (secondes)
+PREVARISC_CACHE_LIFETIME | Durée de vie du cache, actif si valeur > 0 | Valeur numérique (secondes)
+PREVARISC_CACHE_ADAPTER | Adapter backend de cache du cache lié à la factory Zend_Cache, default "APC" | Chaine de caractères
+PREVARISC_CACHE_HOST | Adresse IP du cache backend | Adresse IP
+PREVARISC_CACHE_PORT | Port du cache backend | Valeur numérique
 PREVARISC_SECURITY_SALT | Chaine utilisée pour le cryptage des mots de passe utilisateur | Chaine alphanumérique de longueur 32 (exemple : 7aec3ab8e8d025c19e8fc8b6e0d75227 salt utilisé par défaut)
 PREVARISC_LDAP_ENABLED | [FACULTATIF] Activation de la connexion des utilisateurs via LDAP | 1 ou 0
 PREVARISC_LDAP_HOST | [FACULTATIF] Adresse du serveur LDAP | Adresse IP

--- a/docs/documentation_installation.md
+++ b/docs/documentation_installation.md
@@ -130,6 +130,23 @@ PREVARISC_BRANCH | [FACULTATIF] Forcer la branche de l'installation prévarisc, 
 * Ouvrir Firefox et saisir http://prevarisc.sdis??.fr
 * A ce point vous devez être capable d'accéder à Prevarisc ! Le premier compte utilisateur est ```root```, mot de passe ```root``` (à désactiver le plus rapidement possible pour des raisons de sécurité).
 
+
+## Etape 6 (optionnelle) : installation d'un cache mysql (php>5.4) ##
+
+Pour les installations avec php > 5.4, APC n'est plus supporté. Il faut installer un cache alternatif, mysql par exemple :
+* download du module php memcache
+* Taper : ```tar -xvzf memcache-2.2.7.tgz```
+* Taper : ```cd memcache-2.2.7```
+* Taper : ```phpize```
+* Taper : ```./configure```
+* Taper : ```make```
+* Taper : ```sudo make install```
+* Vérifier que memcache est bien installé ```php -m | grep memcache``` sinon ajout de : ```extension=memcache.so``` dans le php.ini
+* Jouer le sql d'activation du cache, taper : ```mysql -u root -p prevarisc < sql/init/enable_mysql_cache.sql```
+* Taper : ```sudo /etc/init.d/mysql restart```
+* Modifier le vhost apache pour modifier les variables PREVARISC_CACHE_ADAPTER en "Cache_MySQLMemcached" voir PREVARISC_CACHE_HOST si le backend est installé sur une machine distante.
+* Taper : ```sudo /etc/init.d/httpd restart```
+
 # Mise à jour de la base de données de Prevarisc #
 
 Depuis un PC windows, installer le logiciel [MySQL WorkBench](http://www.mysql.fr/products/workbench/).

--- a/public/index.php
+++ b/public/index.php
@@ -53,7 +53,14 @@ $application = new Zend_Application('production', array(
         'baseDn' => getenv('PREVARISC_LDAP_ENABLED') ? getenv('PREVARISC_LDAP_BASEDN') : '',
     ),
     'cache' => array(
-        'lifetime' => getenv('PREVARISC_CACHE_LIFETIME'),
+        'adapter'       => getenv('PREVARISC_CACHE_ADAPTER') ? : 'APC',
+        'customAdapter' => getenv('PREVARISC_CACHE_ADAPTER') !== false,
+        'enabled'      => ((int) getenv('PREVARISC_CACHE_LIFETIME')) > 0,
+        'lifetime'      => (int) getenv('PREVARISC_CACHE_LIFETIME'),
+        'host'          => getenv('PREVARISC_CACHE_HOST'),
+        'port'          => (int) getenv('PREVARISC_CACHE_PORT'),
+        'write_control' => false,
+        'compression'   => false,
     ),
     'security' => array(
         'salt' => getenv('PREVARISC_SECURITY_SALT'),

--- a/sql/init/enable_mysql_cache.sql
+++ b/sql/init/enable_mysql_cache.sql
@@ -1,0 +1,13 @@
+SET NAMES 'utf8';
+
+/* Enables mysql memcache plugin */
+/* Path to mysql cache plugin depends on your installation */
+SOURCE '/usr/share/mysql/innodb_memcached_config.sql';
+INSTALL PLUGIN daemon_memcached SONAME 'libmemcached.so';
+
+/* Declares container configuration and clean previous one*/
+USE innodb_memcache;
+
+DELETE FROM containers;
+INSERT INTO `containers` (`name`, `db_schema`, `db_table`, `key_columns`, `value_columns`, `flags`, `cas_column`, `expire_time_column`, `unique_idx_name_on_key`)
+VALUES ('prevarisc_cache', 'prevarisc', 'cache', 'ID_CACHE', 'VALUE_CACHE', 0, 0, 'EXPIRE_CACHE', 'PRIMARY');

--- a/sql/init/prevarisc.sql
+++ b/sql/init/prevarisc.sql
@@ -2877,3 +2877,15 @@ CREATE TABLE IF NOT EXISTS `prescriptionreglassoc` (
     ON UPDATE CASCADE)
 ENGINE = InnoDB
 DEFAULT CHARACTER SET = utf8;
+
+
+-- -----------------------------------------------------
+-- Table`cache` 
+-- -----------------------------------------------------
+
+CREATE TABLE `cache` (
+  `ID_CACHE` varchar(250) NOT NULL,
+  `VALUE_CACHE` text,
+  `EXPIRE_CACHE` int,
+  PRIMARY KEY (`ID_CACHE`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/sql/migrations/2.4-28_cache.sql
+++ b/sql/migrations/2.4-28_cache.sql
@@ -7,15 +7,3 @@ CREATE TABLE `cache` (
   `EXPIRE_CACHE` int,
   PRIMARY KEY (`ID_CACHE`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
-
-/* Enables mysql memcache plugin */
-/* Path to mysql cache plugin depends on your installation */
-SOURCE '/usr/share/mysql/innodb_memcached_config.sql';
-INSTALL PLUGIN daemon_memcached SONAME 'libmemcached.so';
-
-/* Declares container configuration and clean previous one*/
-USE innodb_memcache;
-
-DELETE FROM containers;
-INSERT INTO `containers` (`name`, `db_schema`, `db_table`, `key_columns`, `value_columns`, `flags`, `cas_column`, `expire_time_column`, `unique_idx_name_on_key`)
-VALUES ('prevarisc_cache', 'prevarisc', 'cache', 'ID_CACHE', 'VALUE_CACHE', 0, 0, 'EXPIRE_CACHE', 'PRIMARY');

--- a/sql/migrations/2.4-28_cache.sql
+++ b/sql/migrations/2.4-28_cache.sql
@@ -1,0 +1,21 @@
+SET NAMES 'utf8';
+
+/* Creates caching table structure in business database */
+CREATE TABLE `cache` (
+  `ID_CACHE` varchar(250) NOT NULL,
+  `VALUE_CACHE` text,
+  `EXPIRE_CACHE` int,
+  PRIMARY KEY (`ID_CACHE`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+/* Enables mysql memcache plugin */
+/* Path to mysql cache plugin depends on your installation */
+SOURCE '/usr/share/mysql/innodb_memcached_config.sql';
+INSTALL PLUGIN daemon_memcached SONAME 'libmemcached.so';
+
+/* Declares container configuration and clean previous one*/
+USE innodb_memcache;
+
+DELETE FROM containers;
+INSERT INTO `containers` (`name`, `db_schema`, `db_table`, `key_columns`, `value_columns`, `flags`, `cas_column`, `expire_time_column`, `unique_idx_name_on_key`)
+VALUES ('prevarisc_cache', 'prevarisc', 'cache', 'ID_CACHE', 'VALUE_CACHE', 0, 0, 'EXPIRE_CACHE', 'PRIMARY');


### PR DESCRIPTION
Préparation de la migration à php5.6 : prise en charge d'un cache alternatif à APC, le moteur nosql de mysql 5.6+. L'interface memcache de mysql est adressée.

Le cache APC reste utilisable après ce commit bien entendu.

Notes de migration vers le cache mysql :
download du module php memcache
tar -xvzf memcache-2.2.7.tgz
cd memcache-2.2.7
phpize
./configure
make
sudo make install
php -m | grep memcache
sinon ajout de  :
extension=memcache.so
jouer le sql de migration
restart mysql
Modification du vhost apache pour modifier les variables PREVARISC_CACHE_ADAPTER en "Cache_MySQLMemcached" voir  PREVARISC_CACHE_HOST si le backend est installé sur une machine distante.
restart apache
