### PR TITLE
Correction de la création d'une adresse pour une commune à 2 caractères

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,7 @@ Corrections :
 * Correction de l'espacement interbloc sur la HP qui décale tout sur 1 colonne sur certains types de petits écrans
 * Correction du cache non vidé pour les parents des établissements lorsqu'un dossier donnant avis est modifié
 * Correction de la génération des convocations qui ne faisait apparaitre que le dernier dossier pour les membres de types commune
+* Correction des communes à 2 caractères, on remonte en 1er celles dont la longueure est minimale
 
 ## 2.3
 

--- a/application/models/DbTable/AdresseCommune.php
+++ b/application/models/DbTable/AdresseCommune.php
@@ -2,14 +2,15 @@
     class Model_DbTable_AdresseCommune extends Zend_Db_Table_Abstract
     {
         protected $_name="adressecommune"; // Nom de la base
-        protected $_primary = "NUMINSEE_COMMUNE"; // Clé primaire
+        protected $_primary = "NUMINSEE_COMMUNE"; // Clï¿½ primaire
 
         public function get($q)
         {
             $select = $this->select()->setIntegrityCheck(false);
 
             $select->from("adressecommune")
-                   ->where("LIBELLE_COMMUNE LIKE ?", "%".$q."%");
+                   ->where("LIBELLE_COMMUNE LIKE ?", "%".$q."%")
+                   ->order('LENGTH(LIBELLE_COMMUNE)');
 
             return $this->fetchAll($select)->toArray();
         }


### PR DESCRIPTION
La création d'une adresse pour une commune à 2 caractères ou moins, qui est contenu dans le nom du reste des autres communes était impossible. Pour contourner le problème, un order est fait sur la longueur du nom de la commune.
