### PR TITLE
Correction du dossier, ajout de deux années pour l'affichage des calendriers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,6 +97,7 @@ Corrections :
 * Correction du cache non vidé pour les parents des établissements lorsqu'un dossier donnant avis est modifié
 * Correction de la génération des convocations qui ne faisait apparaitre que le dernier dossier pour les membres de types commune
 * Correction des communes à 2 caractères, on remonte en 1er celles dont la longueure est minimale
+* Correction du dossier, ajout de deux années pour l'affichage des calendriers
 
 ## 2.3
 

--- a/application/views/scripts/dossier/index.phtml
+++ b/application/views/scripts/dossier/index.phtml
@@ -1342,8 +1342,8 @@ echo "
 						<select id='year_visite' style='width:70px;'>
 					";
                     $annéeActuelle = date("Y");
-                    for ($i = $annéeActuelle; $i >= 1990; $i--) {
-                        echo "<option value='".$i."' >".$i."</option>";
+                    for ($i = $annéeActuelle + 2; $i >= 1990; $i--) {
+                        echo "<option value='".$i."' ".(($annéeActuelle == $i) ? "selected='selected'" : "")." >".$i."</option>";
                     }
                     echo "
 						</select>
@@ -1390,8 +1390,8 @@ echo "
 						<select id='year_comm' style='width:70px;'>
 					";
                     $annéeActuelle = date("Y");
-                    for ($i = $annéeActuelle; $i >= 1990; $i--) {
-                        echo "<option value='".$i."' >".$i."</option>";
+                    for ($i = $annéeActuelle + 2; $i >= 1990; $i--) {
+                        echo "<option value='".$i."' ".(($annéeActuelle == $i) ? "selected='selected'" : "")." >".$i."</option>";
                     }
                     echo "
 						</select>


### PR DESCRIPTION
Dans l'interface de création/modification d'un dossier, ajout de deux années permettant d'afficher directement les calendriers pour 2016 et 2017 afin de permettre la programmation des dossiers en commission sans devoir passer par les flèches du calendrier.
Positionnement automatique de la liste déroulante sur l'année en cours.
