### PR TITLE
Contrôle sur la nullité de la dernière visite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ Evolutions :
 * Ajout du support du cache nosql mysql
 
 Corrections :
+* Ajout des dossiers de nature "Levée de prescriptions" dans les dossiers donnant avis en historique établissement.
 * Correction d'un problème sur les groupements ayant une quote dans leur libelle et/ou dans leur libelle de type de groupement
 * Correction d'un problème sur la remontée d'établissements sans VP dans l'année du à une liste de nature de dossier concerné différente de la fiche info d'un établissement
 * Impossibilité de créer des dossiers en décembre : mauvais validateur de date

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ Evolutions :
 * Ajout du support du cache nosql mysql
 
 Corrections :
+* Correction d'un problème sur les groupements ayant une quote dans leur libelle et/ou dans leur libelle de type de groupement
+* Correction d'un problème sur la remontée d'établissements sans VP dans l'année du à une liste de nature de dossier concerné différente de la fiche info d'un établissement
 * Impossibilité de créer des dossiers en décembre : mauvais validateur de date
 * Sur firefox, sur le tableau de bord, impossible de scroller sur les blocs sans déplacer le bloc avec
 * Ajout d'une image manquante sur tipsy

--- a/application/models/DbTable/Groupement.php
+++ b/application/models/DbTable/Groupement.php
@@ -38,23 +38,28 @@ class Model_DbTable_Groupement extends Zend_Db_Table_Abstract
     
     public function getByLibelle($libelle)
     {
+        $expLibelle = $this->getAdapter()->quote($libelle);
         $select = "SELECT groupement.*, groupementtype.LIBELLE_GROUPEMENTTYPE, utilisateurinformations.*
                     FROM groupement 
                     INNER JOIN groupementtype ON groupement.ID_GROUPEMENTTYPE = groupementtype.ID_GROUPEMENTTYPE 
                     LEFT JOIN utilisateurinformations ON utilisateurinformations.ID_UTILISATEURINFORMATIONS = groupement.ID_UTILISATEURINFORMATIONS 
-                    WHERE (groupement.LIBELLE_GROUPEMENT = '".$libelle."');";
+                    WHERE (groupement.LIBELLE_GROUPEMENT = " . $expLibelle . ");";
         //echo $select;
         //Zend_Debug::dump($DB_information->fetchRow($select));
+        
         return $this->getAdapter()->fetchAll($select);
     }
     
     public function getByLibelle2($libelle, $libelleGroupementType)
     {
+        $expLibelle = $this->getAdapter()->quote($libelle);
+        $expLibelleGroupementType = $this->getAdapter()->quote($libelleGroupementType);
         $select = "SELECT groupement.*, groupementtype.LIBELLE_GROUPEMENTTYPE, utilisateurinformations.*
                     FROM groupement 
                     INNER JOIN groupementtype ON groupement.ID_GROUPEMENTTYPE = groupementtype.ID_GROUPEMENTTYPE 
                     LEFT JOIN utilisateurinformations ON utilisateurinformations.ID_UTILISATEURINFORMATIONS = groupement.ID_UTILISATEURINFORMATIONS 
-                    WHERE (groupement.LIBELLE_GROUPEMENT = '".$libelle."' and groupementtype.LIBELLE_GROUPEMENTTYPE = '".$libelleGroupementType."');";
+                    WHERE (groupement.LIBELLE_GROUPEMENT = " . $expLibelle . " AND groupementtype.LIBELLE_GROUPEMENTTYPE = " . $expLibelleGroupementType . ");";
+       
        return $this->getAdapter()->fetchAll($select);
     }
 

--- a/application/services/Etablissement.php
+++ b/application/services/Etablissement.php
@@ -319,7 +319,7 @@ class Service_Etablissement implements Service_Interface_Etablissement
           $author = null;
 
           if($dossier->AVIS_DOSSIER_COMMISSION && ($dossier->AVIS_DOSSIER_COMMISSION == 1 || $dossier->AVIS_DOSSIER_COMMISSION == 2)) {
-            if( ($dossier->TYPE_DOSSIER == 1 && in_array($dossier->ID_DOSSIERNATURE, array(19))) || ($dossier->TYPE_DOSSIER == 2 && in_array($dossier->ID_DOSSIERNATURE, array(21, 23, 24, 47))) || ($dossier->TYPE_DOSSIER == 3 && in_array($dossier->ID_DOSSIERNATURE, array(26, 28, 29, 48)))) {
+            if( ($dossier->TYPE_DOSSIER == 1 && in_array($dossier->ID_DOSSIERNATURE, array(19, 7))) || ($dossier->TYPE_DOSSIER == 2 && in_array($dossier->ID_DOSSIERNATURE, array(21, 23, 24, 47))) || ($dossier->TYPE_DOSSIER == 3 && in_array($dossier->ID_DOSSIERNATURE, array(26, 28, 29, 48)))) {
               $value = $dossier->AVIS_DOSSIER_COMMISSION == 1 ? "Favorable" : "Défavorable";
             }
           }

--- a/application/services/Etablissement.php
+++ b/application/services/Etablissement.php
@@ -89,13 +89,18 @@ class Service_Etablissement implements Service_Interface_Etablissement
             $next_visite = null;
 
             if ($last_visite !== null && count($last_visite) > 0){
-                $tmp_date = new Zend_Date($last_visite[0]['DATEVISITE_DOSSIER'], Zend_Date::DATES);
-                $last_visite =  $tmp_date->get( Zend_date::DAY." ".Zend_Date::MONTH_NAME." ".Zend_Date::YEAR );
+                if ($last_visite[0]['DATEVISITE_DOSSIER'] !== null) {
+                    $tmp_date = new Zend_Date($last_visite[0]['DATEVISITE_DOSSIER'], Zend_Date::DATES);
+                    $last_visite =  $tmp_date->get( Zend_date::DAY." ".Zend_Date::MONTH_NAME." ".Zend_Date::YEAR );
 
-                if($informations->PERIODICITE_ETABLISSEMENTINFORMATIONS != 0) {
-                    $tmp_date = new Zend_Date($tmp_date->get( Zend_Date::WEEKDAY." ".Zend_Date::DAY_SHORT." ".Zend_Date::MONTH_NAME_SHORT." ".Zend_Date::YEAR ), Zend_Date::DATES);
-                    $tmp_date->add($informations->PERIODICITE_ETABLISSEMENTINFORMATIONS, Zend_Date::MONTH);
-                    $next_visite =  $tmp_date->get(Zend_Date::MONTH_NAME." ".Zend_Date::YEAR );
+                    if($informations->PERIODICITE_ETABLISSEMENTINFORMATIONS != 0) {
+                        $tmp_date = new Zend_Date($tmp_date->get( Zend_Date::WEEKDAY." ".Zend_Date::DAY_SHORT." ".Zend_Date::MONTH_NAME_SHORT." ".Zend_Date::YEAR ), Zend_Date::DATES);
+                        $tmp_date->add($informations->PERIODICITE_ETABLISSEMENTINFORMATIONS, Zend_Date::MONTH);
+                        $next_visite =  $tmp_date->get(Zend_Date::MONTH_NAME." ".Zend_Date::YEAR );
+                    }    
+                }
+                else {
+                    $last_visite = null;
                 }
             }
 


### PR DESCRIPTION
Certains dossiers ont des dates de dernière visite à null, faussant la date de dernière visite périodique dans la fiche information (date du jour affichée).
