### PR TITLE
Plusieurs corrections liées aux prescriptions types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 2.5
+
+Corrections :
+* Corrections sur l'enregistrement des prescriptions types : NUM_PRESCRIPTION_DOSSIER cannot be null
+* Correction sur l'initialisation des listes d'articles / textes dans l'admin à 0px
+
 ## 2.4
 
 Evolutions :

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Corrections :
 * Corrections sur l'enregistrement des prescriptions types : NUM_PRESCRIPTION_DOSSIER cannot be null
 * Correction sur l'initialisation des listes d'articles / textes dans l'admin à 0px
 * Correction des puces pouvant apparaître dans les documents générés s'il n'y a aucune prescription type
+* Correction du champ de fusion {dateDelaipresc} qui affait DELAIPRESC_DOSSIER lorsqu'il n'y avait pas de date
 
 ## 2.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Corrections :
 * Corrections sur l'enregistrement des prescriptions types : NUM_PRESCRIPTION_DOSSIER cannot be null
 * Correction sur l'initialisation des listes d'articles / textes dans l'admin à 0px
+* Correction des puces pouvant apparaître dans les documents générés s'il n'y a aucune prescription type
 
 ## 2.4
 

--- a/application/controllers/DossierController.php
+++ b/application/controllers/DossierController.php
@@ -2245,7 +2245,7 @@ class DossierController extends Zend_Controller_Action
             $dateComm = new Zend_Date($this->view->infosDossier['DELAIPRESC_DOSSIER'], Zend_Date::DATES);
             $this->view->dateDelaipresc = $dateComm->get(Zend_Date::DAY_SHORT." ".Zend_Date::MONTH_NAME." ".Zend_Date::YEAR);
         }else{
-            $this->view->dateDelaipresc = "DELAIPRESC_DOSSIER";
+            $this->view->dateDelaipresc = "Pas de date";
         }
 
         $dateDuJour = new Zend_Date();

--- a/application/services/Dossier.php
+++ b/application/services/Dossier.php
@@ -641,11 +641,13 @@ class Service_Dossier
     {
         $dbPrescDossier = new Model_DbTable_PrescriptionDossier();
         $dbPrescDossierAssoc = new Model_DbTable_PrescriptionDossierAssoc();
+        $j = 0;
         foreach($prescriptionRegl as $val => $ue){
             $prescEdit = $dbPrescDossier->createRow();
             $prescEdit->ID_DOSSIER = $idDossier;
             $prescEdit->LIBELLE_PRESCRIPTION_DOSSIER = $ue[0]['PRESCRIPTIONREGL_LIBELLE'];
             $prescEdit->TYPE_PRESCRIPTION_DOSSIER = 0;
+            $prescEdit->NUM_PRESCRIPTION_DOSSIER = $j++;
             $prescEdit->save();
 
             $nombreAssoc = count($ue);

--- a/application/services/Prescriptions.php
+++ b/application/services/Prescriptions.php
@@ -42,9 +42,9 @@ class Service_Prescriptions
 
         $prescType->PRESCRIPTIONTYPE_LIBELLE = $post['PRESCRIPTIONTYPE_LIBELLE'];
         
-        $prescType->PRESCRIPTIONTYPE_CATEGORIE = $post['PRESCRIPTIONTYPE_CATEGORIE'];
-        $prescType->PRESCRIPTIONTYPE_TEXTE = $post['PRESCRIPTIONTYPE_TEXTE'];
-        $prescType->PRESCRIPTIONTYPE_ARTICLE = $post['PRESCRIPTIONTYPE_ARTICLE'];
+        $prescType->PRESCRIPTIONTYPE_CATEGORIE = (int) $post['PRESCRIPTIONTYPE_CATEGORIE'];
+        $prescType->PRESCRIPTIONTYPE_TEXTE = (int) $post['PRESCRIPTIONTYPE_TEXTE'];
+        $prescType->PRESCRIPTIONTYPE_ARTICLE = (int) $post['PRESCRIPTIONTYPE_ARTICLE'];
 
         $prescType->save();
 

--- a/application/views/scripts/calendrier-des-commissions/generationpv.phtml
+++ b/application/views/scripts/calendrier-des-commissions/generationpv.phtml
@@ -89,14 +89,6 @@ function addPrescription($listePrescription,$type,$odf){
                 $prescription->merge();
             }
 
-        }else{
-
-            if($type != 0){
-                $prescription->setVars('num', '', true, 'UTF-8');
-            }
-            $prescription->setVars('libelle', '', true, 'UTF-8');
-            $prescription->setVars('textearticle','',true,'UTF-8');
-            $prescription->merge();
         }
     }
 

--- a/application/views/scripts/dossier/creationdoc.phtml
+++ b/application/views/scripts/dossier/creationdoc.phtml
@@ -251,13 +251,6 @@ if (!function_exists('addPrescription')) {
                     $prescription->merge();
                 }
 
-            }else{
-                if($type != 0){
-                    addChamp($prescription,'num', '');
-                }
-                addChamp($prescription,'libelle', '');
-                addChamp($prescription,'textearticle', '');
-                $prescription->merge();
             }
             $odf->mergeSegment($prescription);
         } catch (OdfException $e) {

--- a/application/views/scripts/gestion-prescriptions/index.phtml
+++ b/application/views/scripts/gestion-prescriptions/index.phtml
@@ -97,7 +97,7 @@
 
  
 <!-- Modal -->
-<div id="myModal" class="modal hide fade" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" style='width:1000px;margin-left:-500px;' >
+<div id="myModal" class="modal hide" tabindex="-1" role="dialog" aria-labelledby="myModalLabel" aria-hidden="true" style='width:1000px;margin-left:-500px;' >
 	<div class="modal-header">
 		<button type="button" class="close" data-dismiss="modal" aria-hidden="true">×</button>
 		<h3 id="myModalLabel">Gestion prescription type</h3>


### PR DESCRIPTION
- Corrections sur l'enregistrement des prescriptions types : NUM_PRESCRIPTION_DOSSIER cannot be null
- Correction sur l'initialisation des listes d'articles / textes dans l'admin à 0px
- Correction des puces pouvant apparaître dans les documents générés s'il n'y a aucune prescription type
- Correction du champ de fusion {dateDelaipresc} qui affait DELAIPRESC_DOSSIER lorsqu'il n'y avait pas de date
