### PR TITLE
Correction de l'affichage des tinyint sur le descriptif technique des établissements

### DIFF
--- a/application/views/scripts/etablissement/descriptif.phtml
+++ b/application/views/scripts/etablissement/descriptif.phtml
@@ -36,7 +36,7 @@
 	            if(!$value['value'] == null && !$value['value'] == 0)
 	            {
 	            	echo "<dt>".$key."</dt>";
-	                echo "<dd>" . $value['type'] == 'tinyint' ? ( $value['value'] == 1 ? 'Oui' : 'Non') : $value['value'] . "</dd>";
+                        echo "<dd>" . ($value['type'] == 'tinyint' ? ( $value['value'] == 1 ? 'Oui' : 'Non') : $value['value'] ). "</dd>";
 	                $j++;
 	            }
 	        }


### PR DESCRIPTION
Les champs tinyint s'affichent en 1 et 0 au lieu de oui et non
