### PR TITLE
Correction de l'historique d'avis d'exploitation, qui triait mal les lignes d'historique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ Corrections :
 * Correction de la visibilité des dossiers sur les odj des membres communes
 * Correction des communes à 2 caractères, on remonte en 1er celles dont la longueure est minimale
 * Correction du dossier, ajout de deux années pour l'affichage des calendriers
+* Correction des calendriers dans la fiche dossier : ajout de deux annees dans la liste deroulante
+* Correction de l'historique d'avis d'exploitation, qui triait mal les lignes d'historique
 
 ## 2.3
 

--- a/application/services/Etablissement.php
+++ b/application/services/Etablissement.php
@@ -301,14 +301,14 @@ class Service_Etablissement implements Service_Interface_Etablissement
         $dossiers_merged = array_merge($dossiers_merged, $dossiers['autres']);
 
         @usort($dossiers_merged, function($a, $b) {
-
-          $date_a = @new Zend_Date($a->DATEVISITE_DOSSIER != null ? $a->DATEVISITE_DOSSIER : $a->DATECOMM_DOSSIER, Zend_Date::DATES);
-          $date_b = @new Zend_Date($b->DATEVISITE_DOSSIER != null ? $b->DATEVISITE_DOSSIER : $b->DATECOMM_DOSSIER, Zend_Date::DATES);
+          
+          $date_a = @new Zend_Date($a['DATEVISITE_DOSSIER'] != null ? $a['DATEVISITE_DOSSIER'] : $a['DATECOMM_DOSSIER'], Zend_Date::DATES);
+          $date_b = @new Zend_Date($b['DATEVISITE_DOSSIER'] != null ? $b['DATEVISITE_DOSSIER'] : $b['DATECOMM_DOSSIER'], Zend_Date::DATES);
 
           if ($date_a == $date_b || $a === null || $b === null) {
             return 0;
           }
-          else if ($date_a > $date_b) {
+          else if ($date_a < $date_b) {
             return -1;
           }
           else {


### PR DESCRIPTION
Correction de l'historique d'avis d'exploitation qui par un heureux hasard fonctionnait bien, mais sur une reprise de données, le tri des lignes d'historique ne donnait pas le résultat escompté.
