### PR TITLE
Correction du modèle de convocation des groupes de visites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Corrections :
 * Correction du champ de fusion {dateDelaipresc} qui affait DELAIPRESC_DOSSIER lorsqu'il n'y avait pas de date
 * Correction d'un problème de droits sur l'action de validation des documents consultés lorsque l'utilisateur n'a accès qu'aux commissions
 * Correction du retrait d'une méthode dépréciée split
+* Correction du modèle de convocation des groupes de visites qui n'utilisaient pas le modèle de document de visite
 
 ## 2.4
 

--- a/application/views/scripts/calendrier-des-commissions/generationconvoc.phtml
+++ b/application/views/scripts/calendrier-des-commissions/generationconvoc.phtml
@@ -11,14 +11,14 @@ if(count($this->membresFiles) == 0){
 foreach($this->informationsMembre as $val => $membre){
 
 	$erreurFile = 0;
-	if($this->typeCommission == 1 || $this->typeCommission == 3){
+	if($this->typeCommission == 1){
 		if($membre['infosFiles'][0]['COURRIER_CONVOCATIONSALLE'] == NULL){
 			$erreurFile = 1;
 		}else{
 			//Salle
 			$nomFichier = $membre['infosFiles'][0]['ID_COMMISSIONMEMBRE']."CONVOCATIONSALLE_".$membre['infosFiles'][0]['COURRIER_CONVOCATIONSALLE'];
 		}
-	}else if($this->typeCommission == 2){
+	}else if($this->typeCommission == 2 || $this->typeCommission == 3){
 		if($membre['infosFiles'][0]['COURRIER_CONVOCATIONVISITE'] == NULL){
 			$erreurFile = 1;
 		}else{


### PR DESCRIPTION
- Correction du modèle de convocation des groupes de visites qui n'utilisaient pas le modèle de document de visite, mais le modèle de convocation en salle à la place
