### PR TITLE
Prise en compte des chemins Windows pour l'import de document.

### DIFF
--- a/application/controllers/GestionDesDocumentsController.php
+++ b/application/controllers/GestionDesDocumentsController.php
@@ -96,9 +96,11 @@ class GestionDesDocumentsController extends Zend_Controller_Action
             $this->_helper->viewRenderer->setNoRender(true);
             //Si besoin verificaiton de l'extension du fichier (uniquement odt)
             if (move_uploaded_file($_FILES['fichier']['tmp_name'], $this->path . DS. $this->_getParam('commission') .DS. $_FILES['fichier']['name'])) {
+                // Echappement des "backslashes" si le serveur est une machine Windows (Dossier\Fichier => DossierFichier)
+                $filePath = str_replace("\\", "\\\\", $this->_getParam('commission') . DS . $_FILES['fichier']['name']);
                 echo "
                     <script type='text/javascript'>
-                        window.top.window.callback(\"".$this->_getParam('commission') .DS . $_FILES['fichier']['name']."\");
+                        window.top.window.callback('" . $filePath . "');
                     </script>
                 ";
             }


### PR DESCRIPTION
Ceci évite un retour à 'fail' sur le chargement d'un document dans la partie adminsitration > Gestion des documents.
