### PR TITLE
Correction d'un problème d'affichage de la carto IGN sur IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Corrections :
 * Correction du champ de fusion {dateDelaipresc} qui affait DELAIPRESC_DOSSIER lorsqu'il n'y avait pas de date
 * Correction d'un problème de droits sur l'action de validation des documents consultés lorsque l'utilisateur n'a accès qu'aux commissions
 * Correction du retrait d'une méthode dépréciée split
+* Correction d'un problème d'affichage de la carto IGN sur IE11
 
 ## 2.4
 

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -1146,3 +1146,8 @@ a.list-group-item-danger.active:focus {
 #tabPieceJointe .msg{  
     background: url('../images/msg.png') no-repeat;  
 }
+
+/* Fix provenant d'un problème IE11 / bootstrap*/
+#geoportail-container img {
+    max-width: none;
+}


### PR DESCRIPTION
Sur IE11, on voit apparaître des bandes sur la cartographie IGN sur la fiche établissement.
Un bug lié à un conflit ign / bootstrap.
