### PR TITLE
Correction de l'affectation d'un dossier à une autre commission si heures différentes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Corrections :
 * Correction du retrait d'une méthode dépréciée split
 * Correction du port ldap par défaut qui n'est plus inséré par zend sur les connexions LDAP
 * Correction du modèle de convocation des groupes de visites qui n'utilisaient pas le modèle de document de visite
+* Correction de l'affectation d'un dossier à une autre commission, les heures de début et de fin restaient en place ce qui pouvait causer des problèmes lorsque les horaires différaient
 
 ## 2.4
 

--- a/application/controllers/DossierController.php
+++ b/application/controllers/DossierController.php
@@ -1118,6 +1118,9 @@ class DossierController extends Zend_Controller_Action
                             //Dans le cas ou la date commission est différente de celle passée en paramètre alors on la met à jour
                             $dateEdit = $dbDossierAffectation->find($infosDateVisite['ID_DATECOMMISSION_AFFECT'],$idDossier)->current();
                             $dateEdit->ID_DATECOMMISSION_AFFECT = $this->_getParam('ID_AFFECTATION_DOSSIER_VISITE');
+                            $dateEdit->HEURE_DEB_AFFECT = NULL;
+                            $dateEdit->HEURE_FIN_AFFECT = NULL;
+                            $dateEdit->NUM_DOSSIER = 0;
                             $dateEdit->save();
                         }
                     } else {
@@ -1148,6 +1151,9 @@ class DossierController extends Zend_Controller_Action
                             //Dans le cas ou la date commission est différente de celle passée en paramètre alors on la met à jour
                             $dateEdit = $dbDossierAffectation->find($infosDateSalle['ID_DATECOMMISSION_AFFECT'],$idDossier)->current();
                             $dateEdit->ID_DATECOMMISSION_AFFECT = $this->_getParam('ID_AFFECTATION_DOSSIER_COMMISSION');
+                            $dateEdit->HEURE_DEB_AFFECT = NULL;
+                            $dateEdit->HEURE_FIN_AFFECT = NULL;
+                            $dateEdit->NUM_DOSSIER = 0;
                             $dateEdit->save();
                         }
                     } else {


### PR DESCRIPTION
Correction de l'affectation d'un dossier à une autre commission, les heures de début et de fin restaient en place ce qui pouvait causer des problèmes lorsque les horaires différaient
