### PR TITLE
Correction de la {dateVisite} sur les ODJ

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Corrections :
 * Correction du port ldap par défaut qui n'est plus inséré par zend sur les connexions LDAP
 * Correction du modèle de convocation des groupes de visites qui n'utilisaient pas le modèle de document de visite
 * Correction de l'affectation d'un dossier à une autre commission, les heures de début et de fin restaient en place ce qui pouvait causer des problèmes lorsque les horaires différaient
+* Correction de la {dateVisite} sur les ODJ qui était positionnée à la date du jour par défaut si vide
 
 ## 2.4
 

--- a/application/views/scripts/calendrier-des-commissions/generationodj.phtml
+++ b/application/views/scripts/calendrier-des-commissions/generationodj.phtml
@@ -173,9 +173,10 @@ function retrieveInfoDoss($segment, $dossierInfos) {
     }
     addChamp($segment->infosDoss, 'nomPereEtab', $nomPere);
     
-    $dateVisite = new Zend_Date($dossierInfos["DATEVISITE_DOSSIER"]);
     try{
-        addChamp($segment->infosDoss, 'dateVisite', $dateVisite->get(Zend_Date::DAY."/".Zend_Date::MONTH."/".Zend_Date::YEAR));
+        $date = new Zend_Date($dossierInfos["DATEVISITE_DOSSIER"]);
+        $dateVisite = $dossierInfos["DATEVISITE_DOSSIER"] ? $date->get(Zend_Date::DAY."/".Zend_Date::MONTH."/".Zend_Date::YEAR) : '';
+        addChamp($segment->infosDoss, 'dateVisite', $dateVisite);
     } catch (Exception $e){
         addChamp($segment->infosDoss, 'dateVisite', '');
     }


### PR DESCRIPTION
Correction de la {dateVisite} sur les ODJ qui était positionnée à la date du jour par défaut si vide
