### PR TITLE
Correction de la date du doc ajouté sur les levées d'avis défavorables

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ Corrections :
 * Correction de la suppression d'un lien établissement - dossier qui ne changeait pas l'avis de l'établissement
 * Correction d'un problème d'escapiing des quotes sur la recherche des ets
 * Correction d'un problème de géolocalisation si aucune couche WMS n'est paramétrée
+* Correction d'un problème de géolocalisation avec nominatim et du manque de couche WMS sur le viewer d'ajout d'un établissement
+* Correction de l'escaping des quotes sur les plans
+* Correction de l'escaping des noms de fichiers de la gestion des documents
+* Correction de la date du doc ajouté sur les levées d'avis défavorables
 
 ## 2.4
 

--- a/application/controllers/DossierController.php
+++ b/application/controllers/DossierController.php
@@ -882,6 +882,7 @@ class DossierController extends Zend_Controller_Action
                     $docAttestation->LIBELLE_DOCAJOUT = "Attestation de";
                     $docAttestation->ID_NATURE = $idNature;
                     $docAttestation->ID_DOSSIER = $idDossier;
+                    $docAttestation->DATE_DOCAJOUT = '0000-00-00';
                     $docAttestation->save();
                 }
             }


### PR DESCRIPTION
Correction de la date du doc ajouté sur les levées d'avis défavorables qui apparaîssaient non cochés dans l'interface.
