### PR TITLE
Fatal error suppression texte applicable dossiers si inexistant sur ets

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ Corrections :
 * Correction d'un problème d'escapiing des quotes sur la recherche des ets
 * Correction d'un problème de géolocalisation si aucune couche WMS n'est paramétrée
 * Correction d'un problème de géolocalisation avec nominatim et du manque de couche WMS sur le viewer d'ajout d'un établissement
+* Correction de l'escaping des quotes sur les plans
+* Correction de l'escaping des noms de fichiers de la gestion des documents
+* Correction de la date du doc ajouté sur les levées d'avis défavorables
+* Correction du calcul de la périodicité des IGH et KO à l'insert de nouveaux IGH
+* Correction de la non-génération des documents consultés non manuels pour les dossiers de levées d'avis défavorables
+* Correction d'une fatal error sur la suppression d'un texte applicable non existant sur l'établissement
 
 ## 2.4
 

--- a/application/services/Dossier.php
+++ b/application/services/Dossier.php
@@ -197,15 +197,19 @@ class Service_Dossier
         //On récupère le premier établissements afin de mettre à jour ses textes applicables lorsque l'on est dans une visite
         if (2 == $type || 3 == $type) {
             $tabEtablissement = $dbDossier->getEtablissementDossier($id_dossier);
-            $id_etablissement = $tabEtablissement[0]['ID_ETABLISSEMENT'];
+            $id_etablissement = isset($tabEtablissement[0]) ? $tabEtablissement[0]['ID_ETABLISSEMENT'] : null;
         }
 
         foreach ($textes_applicables as $id_texte_applicable => $is_active) {
             if (!$is_active) {
-                if ($dossierTexteApplicable->find($id_texte_applicable, $id_dossier)->current() !== null) {
-                    $dossierTexteApplicable->find($id_texte_applicable, $id_dossier)->current()->delete();
-                    if (2 == $type || 3 == $type) {
-                        $etsTexteApplicable->find($id_texte_applicable, $id_etablissement)->current()->delete();
+                $texte_applicable = $dossierTexteApplicable->find($id_texte_applicable, $id_dossier)->current();
+                if ($texte_applicable !== null) {
+                    $texte_applicable->delete();
+                    if ((2 == $type || 3 == $type) && $id_etablissement) {
+                        $texte_applicable = $etsTexteApplicable->find($id_texte_applicable, $id_etablissement)->current();
+                        if ($texte_applicable !== null) {
+				$texte_applicable->delete();
+			}
                     }
                 }
             } else {
@@ -214,7 +218,7 @@ class Service_Dossier
                     $row->ID_TEXTESAPPL = $id_texte_applicable;
                     $row->ID_DOSSIER = $id_dossier;
                     $row->save();
-                    if (2 == $type || 3 == $type) {
+                    if ((2 == $type || 3 == $type) && $id_etablissement) {
                         $exist = $etsTexteApplicable->find($id_texte_applicable,$id_etablissement)->current();
                         if (! $exist) {
                             $row = $etsTexteApplicable->createRow();


### PR DESCRIPTION
 Correction d'une fatal error sur la suppression d'un texte applicable non existant sur l'établissement, dans certains cas très rares avec des ajouts / suppressions de liens entre établissements et dossiers
