### PR TITLE
Ano avatar et icône

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,12 @@ Corrections :
 * Correction d'un problème de géolocalisation avec nominatim et du manque de couche WMS sur le viewer d'ajout d'un établissement
 * Correction de l'escaping des quotes sur les plans
 * Correction de l'escaping des noms de fichiers de la gestion des documents
+* Correction de la date du doc ajouté sur les levées d'avis défavorables
+* Correction du calcul de la périodicité des IGH et KO à l'insert de nouveaux IGH
+* Correction de la non-génération des documents consultés non manuels pour les dossiers de levées d'avis défavorables
+* Correction d'une fatal error sur la suppression d'un texte applicable non existant sur l'établissement
+* Correction de l'affichage des icônes des fichiers joints en cas d'extension en majuscule
+* Correction de l'image du préventionniste qui était trop grande dans le cas d'une carte IGN
 
 ## 2.4
 

--- a/application/views/scripts/piece-jointe/display.phtml
+++ b/application/views/scripts/piece-jointe/display.phtml
@@ -3,7 +3,7 @@
     <?php /* Lien de la pièce jointe */ ?>
     <td>
         <a 
-            class="file <?php echo substr($pj['EXTENSION_PIECEJOINTE'], 1, 3) ?>"
+            class="file <?php echo substr(strtolower($pj['EXTENSION_PIECEJOINTE']), 1, 3) ?>"
             href='<?php echo $this->url(array('controller' => 'piece-jointe', 'action' => 'get', 'id' => $this->id, 'idpj' => $pj['ID_PIECEJOINTE'], 'type' => $this->type)) ?>' <?php if ($pj['DESCRIPTION_PIECEJOINTE']): ?> title="<?php echo $pj['DESCRIPTION_PIECEJOINTE'] ?>" <?php endif ?> target='_blank' ><?php echo $pj['NOM_PIECEJOINTE'].$pj['EXTENSION_PIECEJOINTE'] ?></a>
     </td>
     

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -412,6 +412,10 @@ a.thumbnail + a.thumbnail {
     margin-left: 5px;
 }
 
+.thumbnail img {
+    width: 100%;
+}
+
 /* 8.Etablissements */
 #ligne_informations {
 


### PR DESCRIPTION
- Correction de l'affichage des icônes des fichiers joints en cas d'extension en majuscule
- Correction de l'image du préventionniste qui était trop grande dans le cas d'une carte IGN
