### PR TITLE
Ajout du champ optionnel {num} pour les prescriptions types de type rappels règlementaires

### DIFF
--- a/application/views/scripts/calendrier-des-commissions/generationpv.phtml
+++ b/application/views/scripts/calendrier-des-commissions/generationpv.phtml
@@ -22,13 +22,13 @@ function addPrescription($listePrescription,$type,$odf){
         try{
 			$prescription = $odf->listeExploitation;
 		} catch (Exception $e) {
-                    throw $e;
+                    
 		}
     }else if ($type == 2){
         try{
 			$prescription = $odf->listeAmelioration;
 		} catch (Exception $e) {
-                    throw $e;
+                    
 		}
     }
 

--- a/application/views/scripts/calendrier-des-commissions/generationpv.phtml
+++ b/application/views/scripts/calendrier-des-commissions/generationpv.phtml
@@ -22,13 +22,13 @@ function addPrescription($listePrescription,$type,$odf){
         try{
 			$prescription = $odf->listeExploitation;
 		} catch (Exception $e) {
-
+                    throw $e;
 		}
     }else if ($type == 2){
         try{
 			$prescription = $odf->listeAmelioration;
 		} catch (Exception $e) {
-
+                    throw $e;
 		}
     }
 
@@ -71,25 +71,29 @@ function addPrescription($listePrescription,$type,$odf){
                     }
                     if($cpt)
                     {
-                        if($type != 0){
-                            $prescription->setVars('num', $listePrescription[$i][0]['NUM_PRESCRIPTION_DOSSIER'], true, 'UTF-8');
-                        }
+                        addChamp($prescription, 'num', $listePrescription[$i][0]['NUM_PRESCRIPTION_DOSSIER']);
 
                         if( $listePrescription[$i][0]['LIBELLE_PRESCRIPTION_DOSSIER'] == '')
                         {
-                            $prescription->setVars('libelle', $listePrescription[$i][0]['PRESCRIPTIONTYPE_LIBELLE'], true, 'UTF-8');
+                            addChamp($prescription, 'libelle', $listePrescription[$i][0]['PRESCRIPTIONTYPE_LIBELLE']);
                         }else{
-                            $prescription->setVars('libelle', $listePrescription[$i][0]['LIBELLE_PRESCRIPTION_DOSSIER'], true, 'UTF-8');
+                            addChamp($prescription, 'libelle', $listePrescription[$i][0]['LIBELLE_PRESCRIPTION_DOSSIER']);
                         }
                         $cpt = false;
                     }
                     $nbCpt--;
                 }
-                $prescription->setVars('textearticle',$textearticle,true,'UTF-8');
+                addChamp($prescription, 'textearticle', $textearticle);
                 $prescription->merge();
             }
 
+        } else {
+            addChamp($prescription, 'num', "");
+            addChamp($prescription, 'libelle', "");
+            addChamp($prescription, 'textearticle', "");
+            $prescription->merge();
         }
+        
     }
 
 }

--- a/application/views/scripts/dossier/creationdoc.phtml
+++ b/application/views/scripts/dossier/creationdoc.phtml
@@ -236,10 +236,8 @@ if (!function_exists('addPrescription')) {
                         }
                         if($cpt)
                         {
-                            if($type != 0){
-                                addChamp($prescription, 'num', $listePrescription[$i][0]['NUM_PRESCRIPTION_DOSSIER']);
-                            }
-
+                            addChamp($prescription, 'num', $listePrescription[$i][0]['NUM_PRESCRIPTION_DOSSIER']);
+                            
                             if( $listePrescription[$i][0]['LIBELLE_PRESCRIPTION_DOSSIER'] == '')
                             {
                                 addChamp($prescription, 'libelle', $listePrescription[$i][0]['PRESCRIPTIONTYPE_LIBELLE']);
@@ -327,30 +325,26 @@ if (!function_exists('addPrescriptionCC')) {
                         }
                         if($cpt)
                         {
-                            if($type != 0){
-                                $prescription->setVars('num', $listePrescription[$i][0]['NUM_PRESCRIPTION_DOSSIER'], true, 'UTF-8');
-                            }
+                            addChamp($prescription, 'num', $listePrescription[$i][0]['NUM_PRESCRIPTION_DOSSIER']);
 
                             if( $listePrescription[$i][0]['LIBELLE_PRESCRIPTION_DOSSIER'] == '')
                             {
-                                $prescription->setVars('libelle', $listePrescription[$i][0]['PRESCRIPTIONTYPE_LIBELLE'], true, 'UTF-8');
+                                addChamp($prescription, 'libelle', $listePrescription[$i][0]['PRESCRIPTIONTYPE_LIBELLE']);
                             }else{
-                                $prescription->setVars('libelle', $listePrescription[$i][0]['LIBELLE_PRESCRIPTION_DOSSIER'], true, 'UTF-8');
+                                addChamp($prescription, 'libelle', $listePrescription[$i][0]['LIBELLE_PRESCRIPTION_DOSSIER']);
                             }
                             $cpt = false;
                         }
                         $nbCpt--;
                     }
-                    $prescription->setVars('textearticle',$textearticle,true,'UTF-8');
+                    addChamp($prescription, 'textearticle', $textearticle);
                     $prescription->merge();
                 }
 
             }else{
-                if($type != 0){ 
-                    $prescription->setVars('num', '', true, 'UTF-8');
-                }
-                $prescription->setVars('libelle', '', true, 'UTF-8');
-                $prescription->setVars('textearticle','',true,'UTF-8');
+                addChamp($prescription, 'num', "");
+                addChamp($prescription, 'libelle', "");
+                addChamp($prescription, 'textearticle', "");
                 $prescription->merge();
             }
         }


### PR DESCRIPTION
Ajout du champ optionnel {num} pour les prescriptions types de type rappels règlementaires (backward compatibility assurée)
Corrections mineures sur la génération de documents.
