### PR TITLE
Correction du nom de rapport téléchargé avec plusieurs établissements

### DIFF
--- a/application/controllers/DossierController.php
+++ b/application/controllers/DossierController.php
@@ -2322,7 +2322,12 @@ class DossierController extends Zend_Controller_Action
         $nouvellePJ->ID_PIECEJOINTE = $this->view->idPieceJointe;
         $nouvellePJ->NOM_PIECEJOINTE = substr(basename($this->view->fichierSelect), 0, strlen(basename($this->view->fichierSelect)) - 3);
         $nouvellePJ->EXTENSION_PIECEJOINTE = ".odt";
-        $nouvellePJ->DESCRIPTION_PIECEJOINTE = "Rapport de l'établissement ".$object_informations['LIBELLE_ETABLISSEMENTINFORMATIONS']." généré le ".$dateDuJour->get(Zend_Date::DAY."/".Zend_Date::MONTH."/".Zend_Date::YEAR)." à ".$dateDuJour->get(Zend_Date::HOUR.":".Zend_Date::MINUTE);
+        $nouvellePJ->DESCRIPTION_PIECEJOINTE = sprintf("Rapport de l'établissement %s (%s) généré le %s à %s",
+                $object_informations['LIBELLE_ETABLISSEMENTINFORMATIONS'],
+                $etablissement['NUMEROID_ETABLISSEMENT'],
+                $dateDuJour->get(Zend_Date::DAY."/".Zend_Date::MONTH."/".Zend_Date::YEAR),
+                $dateDuJour->get(Zend_Date::HOUR.":".Zend_Date::MINUTE)
+        );
         $nouvellePJ->DATE_PIECEJOINTE = $dateDuJour->get(Zend_Date::YEAR."-".Zend_Date::MONTH."-".Zend_Date::DAY);
         $nouvellePJ->save();
 

--- a/application/models/DbTable/EtablissementDossier.php
+++ b/application/models/DbTable/EtablissementDossier.php
@@ -4,13 +4,13 @@
         protected $_name="etablissementdossier";
         protected $_primary = "ID_ETABLISSEMENTDOSSIER";
 
-		public function getEtablissementListe($idDossier)
-		{
-			$select = $this->select()
-				->setIntegrityCheck(false)
-				->from(array('ed' => 'etablissementdossier'))
-				->where("ID_DOSSIER = ?", $idDossier);
+        public function getEtablissementListe($idDossier)
+        {
+                $select = $this->select()
+                        ->setIntegrityCheck(false)
+                        ->from(array('ed' => 'etablissementdossier'))
+                        ->where("ID_DOSSIER = ?", $idDossier);
 
-			return $this->getAdapter()->fetchAll($select);
-		}
+                return $this->getAdapter()->fetchAll($select);
+        }
     }


### PR DESCRIPTION
Correction du nom du fichier téléchargé sur les pièces jointes d'un dossier lorsqu'il y a plusieurs établissements liés : on n'avait que le 1er numéro d'ets précédemment.
