### PR TITLE
Correction du non enregistrement des coordonnées de la commune si la civilite est non renseignee

### DIFF
--- a/application/controllers/GestionDesCommunesController.php
+++ b/application/controllers/GestionDesCommunesController.php
@@ -33,6 +33,8 @@ class GestionDesCommunesController extends Zend_Controller_Action
     public function saveAction()
     {
         try {
+            if(isset($_POST["ID_UTILISATEURCIVILITE"]) && $_POST["ID_UTILISATEURCIVILITE"] == "null")
+                unset($_POST["ID_UTILISATEURCIVILITE"]);
 
             $this->_helper->viewRenderer->setNoRender();
 


### PR DESCRIPTION
Dans l'interface d'administration, correction du non enregistrement des coordonnées de la commune si la civilite est non renseignee.