### PR TITLE
Ajout fonctionnalité d'export Calc de la liste des établissements

### DIFF
--- a/application/controllers/SearchController.php
+++ b/application/controllers/SearchController.php
@@ -10,6 +10,10 @@ class SearchController extends Zend_Controller_Action
     public function etablissementAction()
     {
         $this->_helper->layout->setLayout('search');
+        
+        // Gestion droit export Calc
+        $cache = Zend_Controller_Front::getInstance()->getParam('bootstrap')->getResource('cache');
+        $this->view->is_allowed_export_calc = unserialize($cache->load('acl'))->isAllowed(Zend_Auth::getInstance()->getIdentity()['group']['LIBELLE_GROUPE'], "export", "export_ets");
 
         $service_search = new Service_Search;
 
@@ -20,45 +24,235 @@ class SearchController extends Zend_Controller_Action
         $service_typeactivite = new Service_TypeActivite;
         $service_famille = new Service_Famille;
         $service_classe = new Service_Classe;
+        $service_commission = new Service_Commission;
+        $service_groupementcommunes = new Service_GroupementCommunes();
 
         $this->view->DB_genre = $service_genre->getAll();
         $this->view->DB_statut = $service_statut->getAll();
         $this->view->DB_avis = $service_avis->getAll();
-        $this->view->DB_classe = $service_classe->getAll();
         $this->view->DB_categorie = $service_categorie->getAll();
         $this->view->DB_typeactivite = $service_typeactivite->getAllWithTypes();
         $this->view->DB_famille = $service_famille->getAll();
+        $this->view->DB_classe = $service_classe->getAll();
+        $this->view->DB_commission = $service_commission->getAll();
+        $typeGroupementTerritorial = array(5);
+        $this->view->DB_groupementterritorial = $service_groupementcommunes->findGroupementForGroupementType($typeGroupementTerritorial);
 
         if($this->_request->isGet() && count($this->_request->getQuery()) > 0) {
-            try {
-                $parameters = $this->_request->getQuery();
-                $page = array_key_exists('page', $parameters) ? $parameters['page'] : null;
-                $label = array_key_exists('label', $parameters) && $parameters['label'] != '' && (string) $parameters['label'][0] != '#' ? $parameters['label'] : null;
-                $identifiant = array_key_exists('label', $parameters) && $parameters['label'] != '' && (string) $parameters['label'][0] == '#'? substr($parameters['label'], 1) : null;
-                $genres = array_key_exists('genres', $parameters) ? $parameters['genres'] : null;
-                $categories = array_key_exists('categories', $parameters) ? $parameters['categories'] : null;
-                $classes = array_key_exists('classes', $parameters) ? $parameters['classes'] : null;
-                $familles = array_key_exists('familles', $parameters) ? $parameters['familles'] : null;
-                $types_activites = array_key_exists('types_activites', $parameters) ? $parameters['types_activites'] : null;
-                $avis_favorable = array_key_exists('avis', $parameters) && count($parameters['avis']) == 1 ? $parameters['avis'][0] == 'true' : null;
-                $statuts = array_key_exists('statuts', $parameters) ? $parameters['statuts'] : null;
-                $local_sommeil = array_key_exists('presences_local_sommeil', $parameters) && count($parameters['presences_local_sommeil']) == 1 ? $parameters['presences_local_sommeil'][0] == 'true' : null;
-                $city = array_key_exists('city', $parameters) && $parameters['city'] != '' ? $parameters['city'] : null;
-                $street = array_key_exists('street', $parameters) && $parameters['street'] != '' ? $parameters['street'] : null;
-
-                $search = $service_search->etablissements($label, $identifiant, $genres, $categories, $classes, $familles, $types_activites, $avis_favorable, $statuts, $local_sommeil, null, null, null, $city, $street, 50, $page);
-
-                $paginator = new Zend_Paginator(new SDIS62_Paginator_Adapter_Array($search['results'], $search['search_metadata']['count']));
-                $paginator->setItemCountPerPage(50)->setCurrentPageNumber($page)->setDefaultScrollingStyle('Elastic');
-
-                $this->view->results = $paginator;
-            }
-            catch(Exception $e) {
-                $this->_helper->flashMessenger(array('context' => 'error','title' => 'Problème de recherche','message' => 'La recherche n\'a pas été effectué correctement. Veuillez rééssayez. (' . $e->getMessage() . ')'));
-            }
+        	
+        	if (!empty($_GET)) {
+        		
+        		// Export Calc
+        		if (isset($_GET['Exporter'])) {
+        			 
+        			try {
+        		
+        				$parameters = $this->_request->getQuery();
+        				$page = array_key_exists('page', $parameters) ? $parameters['page'] : null;
+        				$label = array_key_exists('label', $parameters) && $parameters['label'] != '' && (string) $parameters['label'][0] != '#' ? $parameters['label'] : null;
+        				$identifiant = array_key_exists('label', $parameters) && $parameters['label'] != '' && (string) $parameters['label'][0] == '#'? substr($parameters['label'], 1) : null;
+        				$genres = array_key_exists('genres', $parameters) ? $parameters['genres'] : null;
+        				$categories = array_key_exists('categories', $parameters) ? $parameters['categories'] : null;
+        				$classes = array_key_exists('classes', $parameters) ? $parameters['classes'] : null;
+        				$familles = array_key_exists('familles', $parameters) ? $parameters['familles'] : null;
+        				$types_activites = array_key_exists('types_activites', $parameters) ? $parameters['types_activites'] : null;
+        				$avis_favorable = array_key_exists('avis', $parameters) && count($parameters['avis']) == 1 ? $parameters['avis'][0] == 'true' : null;
+        				$statuts = array_key_exists('statuts', $parameters) ? $parameters['statuts'] : null;
+        				$local_sommeil = array_key_exists('presences_local_sommeil', $parameters) && count($parameters['presences_local_sommeil']) == 1 ? $parameters['presences_local_sommeil'][0] == 'true' : null;
+        				$city = array_key_exists('city', $parameters) && $parameters['city'] != '' ? $parameters['city'] : null;
+        				$street = array_key_exists('street', $parameters) && $parameters['street'] != '' ? $parameters['street'] : null;
+        				$commissions = array_key_exists('commissions', $parameters) && $parameters['commissions'] != '' ? $parameters['commissions'] : null;
+        				$groupements_territoriaux = array_key_exists('groupements_territoriaux', $parameters) && $parameters['groupements_territoriaux'] != '' ? $parameters['groupements_territoriaux'] : null;
+        		
+        				$search = $service_search->extractionEtablissements($label, $identifiant, $genres, $categories, $classes, $familles, $types_activites, $avis_favorable, $statuts, $local_sommeil, null, null, null, $city, $street, $commissions, $groupements_territoriaux);
+        				
+        				// Gestion du cache pour ne pas dépasser la taille maximale authorisée
+        				//$cacheMethod = PHPExcel_CachedObjectStorageFactory:: cache_to_phpTemp;
+        				//$cacheSettings = array( ' memoryCacheSize ' => '8MB');
+        				//PHPExcel_Settings::setCacheStorageMethod($cacheMethod, $cacheSettings);
+        				 
+        				$objPHPExcel = new PHPExcel ();
+        				$objPHPExcel->setActiveSheetIndex ( 0 );
+        				$sheet = $objPHPExcel->getActiveSheet ();
+        				$sheet->setTitle ( 'Liste des établissements' );
+        				 
+        				$objPHPExcel->getDefaultStyle()->getFont()->setName('Arial')->setSize(10)->setBold(false);
+        				$sheet->getDefaultRowDimension()->setRowHeight(-1);
+        				 
+        				// Formattage des titres de colonnes
+        				$styleArray = array(
+        						'borders' => array(
+        								'allborders' => array(
+        										'style' => PHPExcel_Style_Border::BORDER_THIN
+        								)
+        						)
+        				);
+        				$sheet->getStyle('A1:T1')->applyFromArray($styleArray);
+        				unset($styleArray);
+        				$sheet->getStyle('A1:T1')->getAlignment()->setHorizontal(PHPExcel_Style_Alignment::HORIZONTAL_CENTER);
+        				$sheet->getStyle('A1:T1')->getFont()->setSize(11)->setBold(true);
+        				 
+        				foreach(range('A','T') as $columnID) {
+        					$sheet->getColumnDimension($columnID)->setAutoSize(true);
+        				}
+        				 
+        				$sheet->setCellValueByColumnAndRow ( 0, 1, "Commune" );
+        				$sheet->setCellValueByColumnAndRow ( 1, 1, "Catégorie" );
+        				$sheet->setCellValueByColumnAndRow ( 2, 1, "Type" );
+        				$sheet->setCellValueByColumnAndRow ( 3, 1, "Activité" );
+        				$sheet->setCellValueByColumnAndRow ( 4, 1, "Commission compétente" );
+        				$sheet->setCellValueByColumnAndRow ( 5, 1, "Code/identifiant établissement" );
+        				$sheet->setCellValueByColumnAndRow ( 6, 1, "Libellé établissement" );
+        				$sheet->setCellValueByColumnAndRow ( 7, 1, "Statut" );
+        				$sheet->setCellValueByColumnAndRow ( 8, 1, "Avis" );
+        				$sheet->setCellValueByColumnAndRow ( 9, 1, "Date du dernier avis" );
+        				$sheet->setCellValueByColumnAndRow ( 10, 1, "Date du premier avis défavorable consécutif" );
+        				$sheet->setCellValueByColumnAndRow ( 11, 1, "Effectif total" );
+        				$sheet->setCellValueByColumnAndRow ( 12, 1, "Effectif public" );
+        				$sheet->setCellValueByColumnAndRow ( 13, 1, "Effectif personnel" );
+        				$sheet->setCellValueByColumnAndRow ( 14, 1, "Date de dernière visite" );
+        				$sheet->setCellValueByColumnAndRow ( 15, 1, "Date de prochaine visite" );
+        				$sheet->setCellValueByColumnAndRow ( 16, 1, "Adresse" );
+        				$sheet->setCellValueByColumnAndRow ( 17, 1, "Groupement territorial compétent" );
+        				$sheet->setCellValueByColumnAndRow ( 18, 1, "Libellé du père/site" );
+        				$sheet->setCellValueByColumnAndRow ( 19, 1, "Genre" );
+        				 
+        				$ligne = 2;
+        				foreach ($search['results'] as $row) {
+        					 
+        					$sheet->setCellValueByColumnAndRow ( 0, $ligne, $row ['LIBELLE_COMMUNE'] );
+        					$sheet->setCellValueByColumnAndRow ( 1, $ligne, $row ['LIBELLE_CATEGORIE'] );
+        					$sheet->setCellValueByColumnAndRow ( 2, $ligne, $row ['LIBELLE_TYPE'] );
+        					$sheet->setCellValueByColumnAndRow ( 3, $ligne, $row ['LIBELLE_ACTIVITE'] );
+        					$sheet->setCellValueByColumnAndRow ( 4, $ligne, $row ['LIBELLE_COMMISSION'] );
+        					$sheet->setCellValueByColumnAndRow ( 5, $ligne, $row ['NUMEROID_ETABLISSEMENT'] );
+        					$sheet->setCellValueByColumnAndRow ( 6, $ligne, $row ['LIBELLE_ETABLISSEMENTINFORMATIONS'] );
+        					$sheet->setCellValueByColumnAndRow ( 7, $ligne, $row ['LIBELLE_STATUT'] );
+        					$sheet->setCellValueByColumnAndRow ( 8, $ligne, $row ['LIBELLE_AVIS'] );
+        					 
+        					if ($row ['DATE_DERNIER_AVIS'] != '') {
+        						$dateDernierAvis = explode("-",$row ['DATE_DERNIER_AVIS']);
+        						$datetimeDernierAvis = PHPExcel_Shared_Date::FormattedPHPToExcel($dateDernierAvis[0], $dateDernierAvis[1], $dateDernierAvis[2]);
+        						$sheet->setCellValueByColumnAndRow ( 9, $ligne, $datetimeDernierAvis );
+        						$sheet->getStyleByColumnAndRow( 9, $ligne)->getNumberFormat()->setFormatCode(PHPExcel_Style_NumberFormat::FORMAT_DATE_DDMMYYYY);
+        					}
+        					 
+        					if ($row ['DATE_PREMIER_AVIS_DEFAVORABLE_CONSECUTIF'] != '') {
+        						$datePremierAvisDefavorableConsecutif = explode("-",$row ['DATE_PREMIER_AVIS_DEFAVORABLE_CONSECUTIF']);
+        						$datetimePremierAvisDefavorableConsecutif = PHPExcel_Shared_Date::FormattedPHPToExcel($datePremierAvisDefavorableConsecutif[0], $datePremierAvisDefavorableConsecutif[1], $datePremierAvisDefavorableConsecutif[2]);
+        						$sheet->setCellValueByColumnAndRow ( 10, $ligne, $datetimePremierAvisDefavorableConsecutif );
+        						$sheet->getStyleByColumnAndRow( 10, $ligne)->getNumberFormat()->setFormatCode(PHPExcel_Style_NumberFormat::FORMAT_DATE_DDMMYYYY);
+        					}
+        					 
+        					$sheet->setCellValueByColumnAndRow ( 11, $ligne, $row ['EFFECTIFPUBLIC_ETABLISSEMENTINFORMATIONS'] + $row ['EFFECTIFPERSONNEL_ETABLISSEMENTINFORMATIONS'] );
+        					$sheet->setCellValueByColumnAndRow ( 12, $ligne, $row ['EFFECTIFPUBLIC_ETABLISSEMENTINFORMATIONS'] );
+        					$sheet->setCellValueByColumnAndRow ( 13, $ligne, $row ['EFFECTIFPERSONNEL_ETABLISSEMENTINFORMATIONS'] );
+        					 
+        					if ($row ['DATE_DERNIERE_VISITE'] != '') {
+        						 
+        						$dateDerniereVisite = explode("-",$row ['DATE_DERNIERE_VISITE']);
+        						$datetimeDerniereVisite = PHPExcel_Shared_Date::FormattedPHPToExcel($dateDerniereVisite[0], $dateDerniereVisite[1], $dateDerniereVisite[2]);
+        						$sheet->setCellValueByColumnAndRow ( 14, $ligne, $datetimeDerniereVisite );
+        						$sheet->getStyleByColumnAndRow( 14, $ligne)->getNumberFormat()->setFormatCode(PHPExcel_Style_NumberFormat::FORMAT_DATE_DDMMYYYY);
+        						 
+        						if($row ['PERIODICITE_ETABLISSEMENTINFORMATIONS'] != 0) {
+        							 
+        							$dateProchaineVisite = date ( 'Y-m-j' , strtotime("+".$row ['PERIODICITE_ETABLISSEMENTINFORMATIONS']." months", strtotime($row ['DATE_DERNIERE_VISITE'])) );
+        							$dateProchaineVisite = explode("-",$dateProchaineVisite);
+        							$datetimeProchaineVisite = PHPExcel_Shared_Date::FormattedPHPToExcel($dateProchaineVisite[0], $dateProchaineVisite[1], $dateProchaineVisite[2]);
+        							$sheet->setCellValueByColumnAndRow(15, $ligne, $datetimeProchaineVisite);
+        							$sheet->getStyleByColumnAndRow(15, $ligne)->getNumberFormat()->setFormatCode(PHPExcel_Style_NumberFormat::FORMAT_DATE_DDMMYYYY);
+        		
+        						}
+        						 
+        					}
+        		
+        					$sheet->setCellValueByColumnAndRow ( 16, $ligne, $row ['NUMERO_ADRESSE'] . " " . $row ['LIBELLE_RUE'] . " " . $row ['COMPLEMENT_ADRESSE'] . " " . $row ['CODEPOSTAL_COMMUNE'] );
+        					$sheet->setCellValueByColumnAndRow ( 17, $ligne, $row ['LIBELLE_GROUPEMENT'] );
+        					$sheet->setCellValueByColumnAndRow ( 18, $ligne, $row ['LIBELLE_ETABLISSEMENT_PERE'] );
+        					$sheet->setCellValueByColumnAndRow ( 19, $ligne, $row ['LIBELLE_GENRE'] );
+        					 
+        					$ligne ++;
+        				}
+        				 
+        				$this->view->writer = PHPExcel_IOFactory::createWriter ( $objPHPExcel, 'Excel5' );
+        				 
+        				// Ensuite j'ai choisi de désactiver mon layout
+        				$this->_helper->layout ()->disableLayout ();
+        				 
+        				header("Content-Type: application/vnd.oasis.opendocument.spreadsheet");
+        				header("Content-Disposition: attachment; filename=\"Export_Etablissements_".date('Y-m-d_H-i-s').".ods\"");
+        				$this->view->writer->save('php://output');
+        				exit();
+        				 
+        			} catch ( Exception $e ) {
+        				$this->_helper->flashMessenger ( array (
+        						'context' => 'error',
+        						'title' => 'Problème d\'export',
+        						'message' => 'L\'export a rencontré un problème. Veuillez rééssayez. (' . $e->getMessage () . ')'
+        				) );
+        			}
+        			 
+        		} else {
+        		// Recherche
+        			
+        			// Si premier affichage de la page
+        			if (!isset($_GET['Rechercher'])) {
+        				// Si l'utilisateur est rattaché à un groupement territorial, présélection de celui-ci dans le filtre
+        				$service_user = new Service_User;
+        				$this->view->user = $service_user->find(Zend_Auth::getInstance()->getIdentity()['ID_UTILISATEUR']);
+        			}
+        			
+        			try {
+        			
+        				$parameters = $this->_request->getQuery();
+        				$page = array_key_exists('page', $parameters) ? $parameters['page'] : null;
+        				$label = array_key_exists('label', $parameters) && $parameters['label'] != '' && (string) $parameters['label'][0] != '#' ? $parameters['label'] : null;
+        				$identifiant = array_key_exists('label', $parameters) && $parameters['label'] != '' && (string) $parameters['label'][0] == '#'? substr($parameters['label'], 1) : null;
+        				$genres = array_key_exists('genres', $parameters) ? $parameters['genres'] : null;
+        				$categories = array_key_exists('categories', $parameters) ? $parameters['categories'] : null;
+        				$classes = array_key_exists('classes', $parameters) ? $parameters['classes'] : null;
+        				$familles = array_key_exists('familles', $parameters) ? $parameters['familles'] : null;
+        				$types_activites = array_key_exists('types_activites', $parameters) ? $parameters['types_activites'] : null;
+        				$avis_favorable = array_key_exists('avis', $parameters) && count($parameters['avis']) == 1 ? $parameters['avis'][0] == 'true' : null;
+        				$statuts = array_key_exists('statuts', $parameters) ? $parameters['statuts'] : null;
+        				$local_sommeil = array_key_exists('presences_local_sommeil', $parameters) && count($parameters['presences_local_sommeil']) == 1 ? $parameters['presences_local_sommeil'][0] == 'true' : null;
+        				$city = array_key_exists('city', $parameters) && $parameters['city'] != '' ? $parameters['city'] : null;
+        				$street = array_key_exists('street', $parameters) && $parameters['street'] != '' ? $parameters['street'] : null;
+        				$commissions = array_key_exists('commissions', $parameters) && $parameters['commissions'] != '' ? $parameters['commissions'] : null;
+        				if (array_key_exists('groupements_territoriaux', $parameters) && $parameters['groupements_territoriaux'] != '') {
+        					$groupements_territoriaux = $parameters['groupements_territoriaux'];
+        				} else {
+        					if ($this->view->user != null && array_key_exists('groupements', $this->view->user) && count($this->view->user['groupements']) > 0) {
+        						$groupements_territoriaux = array();
+        						foreach ($this->view->user['groupements'] as $groupement) {
+        							if ($groupement['ID_GROUPEMENT'] != null) {
+        								array_push($groupements_territoriaux, $groupement['ID_GROUPEMENT']);
+        							}
+        						}
+        					} else {
+        						$groupements_territoriaux = null;
+        					}
+        				}
+        				
+        				$search = $service_search->etablissements($label, $identifiant, $genres, $categories, $classes, $familles, $types_activites, $avis_favorable, $statuts, $local_sommeil, null, null, null, $city, $street, $commissions, $groupements_territoriaux, 50, $page);
+        			
+        				$paginator = new Zend_Paginator(new SDIS62_Paginator_Adapter_Array($search['results'], $search['search_metadata']['count']));
+        				$paginator->setItemCountPerPage(50)->setCurrentPageNumber($page)->setDefaultScrollingStyle('Elastic');
+        			
+        				$this->view->results = $paginator;
+        			
+        			} catch(Exception $e) {
+        				$this->_helper->flashMessenger(array('context' => 'error','title' => 'Problème de recherche','message' => 'La recherche n\'a pas été effectué correctement. Veuillez rééssayez. (' . $e->getMessage() . ')'));
+        			}
+        			
+        		}
+        		
+        	}
+            
         }
     }
-
+    
     public function dossierAction()
     {
         $this->_helper->layout->setLayout('search');
@@ -151,7 +345,7 @@ class SearchController extends Zend_Controller_Action
         $service_search = new Service_Search;
 
         if($this->_request->items == 'etablissement') {
-            $data = $service_search->etablissements(null, null, null, null, null, null, null, null, null, null, null, null, $this->_request->parent, null, null, 1000);
+            $data = $service_search->etablissements(null, null, null, null, null, null, null, null, null, null, null, null, $this->_request->parent, null, null, null, null, 1000);
         }
         else {
             $data = $service_search->dossiers(null, null, null, $this->_request->parent, null, 100);

--- a/application/models/DbTable/Groupement.php
+++ b/application/models/DbTable/Groupement.php
@@ -138,8 +138,8 @@ class Model_DbTable_Groupement extends Zend_Db_Table_Abstract
         return $this->fetchAll($select)->toArray();
     }
 
-    public function getByEtablissement(array $ids_etablissement = array()) {
-
+    public function getByEtablissement(array $ids_etablissement = array())
+    {
         $select = $this	->select()
                         ->setIntegrityCheck(false)
                         ->from("etablissementadresse", array("etablissementadresse.ID_ETABLISSEMENT"))
@@ -152,4 +152,15 @@ class Model_DbTable_Groupement extends Zend_Db_Table_Abstract
 
         return $this->fetchAll($select)->toArray();
     }
+    
+    public function getByGroupementType(array $types_groupement = array())
+    {
+    	$select = $this	->select()
+				    	->setIntegrityCheck(false)
+				    	->from("groupement")
+				    	->where("groupement.ID_GROUPEMENTTYPE IN(?)", $types_groupement);
+    
+    	return $this->fetchAll($select)->toArray();
+    }
+   
 }

--- a/application/modules/api/services/Search.php
+++ b/application/modules/api/services/Search.php
@@ -22,10 +22,10 @@ class Api_Service_Search
      * @param int $page par défaut = 1
      * @return string
      */
-    public function etablissements($label = null, $identifiant = null, $genres = null, $categories = null, $classes = null, $familles = null, $types_activites = null, $avis_favorable = null, $statuts = null, $local_sommeil = null, $lon = null, $lat = null, $parent = null, $count = 10, $page = 1)
+    public function etablissements($label = null, $identifiant = null, $genres = null, $categories = null, $classes = null, $familles = null, $types_activites = null, $avis_favorable = null, $statuts = null, $local_sommeil = null, $lon = null, $lat = null, $parent = null, $commissions = null, $groupements_territoriaux = null, $count = 10, $page = 1)
     {
         $service_search = new Service_Search;
-        $results = $service_search->etablissements($label, $identifiant, $genres, $categories, $classes, $familles, $types_activites, $avis_favorable, $statuts, $local_sommeil, $lon, $lat, $parent, null, null, $count, $page);
+        $results = $service_search->etablissements($label, $identifiant, $genres, $categories, $classes, $familles, $types_activites, $avis_favorable, $statuts, $local_sommeil, $lon, $lat, $parent, null, null, $commissions, $groupements_territoriaux, $count, $page);
         return $results;
     }
 

--- a/application/services/GroupementCommunes.php
+++ b/application/services/GroupementCommunes.php
@@ -37,4 +37,11 @@ class Service_GroupementCommunes
 
         return $model_groupement->getByEtablissement($ids_etablissement);
     }
+    
+    public function findGroupementForGroupementType(array $types_groupement = array())
+    {
+    	$model_groupement = new Model_DbTable_Groupement;
+    
+    	return $model_groupement->getByGroupementType($types_groupement);
+    }
 }

--- a/application/views/scripts/search/etablissement.phtml
+++ b/application/views/scripts/search/etablissement.phtml
@@ -4,8 +4,8 @@
 
 	<div class='navbar-form form-search well well-small' style='margin-bottom: 5px;'>
             <div class="input-append pull-left">
-                <input type="text" name='label' class="input-xlarge search-query" placeholder="Libellé de l'établissement ou son #ID ..." value="<?php if(isset($_GET["label"])) echo htmlentities($_GET["label"]) ?>" />
-                <input type='submit' class="btn btn_search" value="Rechercher" disabled />
+                <input type="text" name='label' class="input-xlarge search-query" placeholder="Libellé de l'établissement ou son #ID ..." value="<?php if(isset($_GET["label"])) echo htmlentities($_GET["label"]) ?>" onkeypress="masquerBoutonExportCalc()"/>
+                <input type='submit' class="btn btn_search" name='Rechercher' value="Rechercher" disabled onsubmit="afficherBoutonExportCalc()"/>
                 <input type='hidden' name='page' value="1" />
             </div>
 
@@ -33,42 +33,42 @@
 	    </p>
 	</div>
 
-        <div id="filterContainer" class="well span12" style="margin-left: 0;">
-            <div>
-                <select name='statuts[]' multiple>
-                    <?php foreach( $this->DB_statut as $statut ) : ?>
-                            <option value='<?php echo $statut["ID_STATUT"] ?>' <?php if(isset($_GET["statuts"]) && in_array($statut["ID_STATUT"], (array) $_GET["statuts"])) echo 'selected' ?>><?php echo $statut["LIBELLE_STATUT"] ?></option>
-                    <?php endforeach ?>
-                </select>
+    <div id="filterContainer" class="well span12" style="margin-left: 0;">
+        <div>
+            <select name='statuts[]' multiple onchange="masquerBoutonExportCalc()">
+                <?php foreach( $this->DB_statut as $statut ) : ?>
+                        <option value='<?php echo $statut["ID_STATUT"] ?>' <?php if(isset($_GET["statuts"]) && in_array($statut["ID_STATUT"], (array) $_GET["statuts"])) echo 'selected' ?>><?php echo $statut["LIBELLE_STATUT"] ?></option>
+                <?php endforeach ?>
+            </select>
 
-                <select name='presences_local_sommeil[]' multiple>
-                    <option value='true' <?php if(isset($_GET["presences_local_sommeil"]) && in_array('true', (array) $_GET["presences_local_sommeil"])) echo 'selected' ?>>Avec</option>
-                    <option value='false' <?php if(isset($_GET["presences_local_sommeil"]) && in_array('false', (array) $_GET["presences_local_sommeil"])) echo 'selected' ?>>Sans</option>
-                </select>
+            <select name='presences_local_sommeil[]' multiple onchange="masquerBoutonExportCalc()">
+                <option value='true' <?php if(isset($_GET["presences_local_sommeil"]) && in_array('true', (array) $_GET["presences_local_sommeil"])) echo 'selected' ?>>Avec</option>
+                <option value='false' <?php if(isset($_GET["presences_local_sommeil"]) && in_array('false', (array) $_GET["presences_local_sommeil"])) echo 'selected' ?>>Sans</option>
+            </select>
 
-                <select name='avis[]' multiple>
-                    <option value='true' <?php if(isset($_GET["avis"]) && in_array('true', (array) $_GET["avis"])) echo 'selected' ?>>Favorable</option>
-                    <option value='false' <?php if(isset($_GET["avis"]) && in_array('false', (array) $_GET["avis"])) echo 'selected' ?>>Défavorable</option>
-                </select>
+            <select name='avis[]' multiple onchange="masquerBoutonExportCalc()">
+                <option value='true' <?php if(isset($_GET["avis"]) && in_array('true', (array) $_GET["avis"])) echo 'selected' ?>>Favorable</option>
+                <option value='false' <?php if(isset($_GET["avis"]) && in_array('false', (array) $_GET["avis"])) echo 'selected' ?>>Défavorable</option>
+            </select>
         </div>
 
-        <div id='criteres_plus' style='margin-top: 4px'>
-            <select name='genres[]' multiple>
+        <div id='criteres_plus' style='margin-top: 4px; margin-bottom: 4px'>
+            <select name='genres[]' multiple onchange="masquerBoutonExportCalc()">
             <?php foreach( $this->DB_genre as $genre ) : ?>
                     <option value='<?php echo $genre["ID_GENRE"] ?>' <?php if(array_key_exists('genres', $_GET) && in_array($genre["ID_GENRE"], (array) $_GET["genres"])) echo 'selected' ?>><?php echo $genre["LIBELLE_GENRE"] ?></option>
             <?php endforeach ?>
             </select>
 
             <span id='categorie_span' class='hide'>
-                    <select name='categories[]' multiple>
+                <select name='categories[]' multiple onchange="masquerBoutonExportCalc()">
                             <?php foreach( $this->DB_categorie as $categorie ) : ?>
                     <option value='<?php echo $categorie["ID_CATEGORIE"] ?>' <?php if(array_key_exists('categories', $_GET) && in_array($categorie["ID_CATEGORIE"], (array) $_GET["categories"])) echo 'selected' ?>><?php echo $categorie["LIBELLE_CATEGORIE"] ?></option>
                     <?php endforeach ?>
-                    </select>
+                </select>
             </span>
 
             <span id='classe_span' class='hide' >
-                <select name='classes[]' multiple>
+                <select name='classes[]' multiple onchange="masquerBoutonExportCalc()">
                     <?php foreach( $this->DB_classe as $classe ) : ?>
                         <option value='<?php echo $classe["ID_CLASSE"] ?>' <?php if(array_key_exists('classes', $_GET) && in_array($classe["ID_CLASSE"], (array) $_GET["classes"])) echo 'selected' ?>><?php echo $classe["LIBELLE_CLASSE"] ?></option>
                     <?php endforeach ?>
@@ -76,7 +76,7 @@
             </span>
 
             <span id='famille_span' class='hide'>
-                <select name='familles[]' multiple>
+                <select name='familles[]' multiple onchange="masquerBoutonExportCalc()">
                     <?php foreach( $this->DB_famille as $famille ) : ?>
                                 <option value='<?php echo $famille["ID_FAMILLE"] ?>' <?php if(array_key_exists('familles', $_GET) && in_array($famille["ID_FAMILLE"], (array) $_GET["familles"])) echo 'selected' ?>><?php echo $famille["LIBELLE_FAMILLE"] ?></option>
                     <?php endforeach ?>
@@ -84,7 +84,7 @@
             </span>
 
             <span id='type_span' class='hide'>
-                <select name='types_activites[]' multiple>
+                <select name='types_activites[]' multiple onchange="masquerBoutonExportCalc()">
                     <?php foreach( $this->DB_typeactivite as $type ) : ?>
 						<optgroup label="<?php echo $type["LIBELLE_TYPE"] ?>">
 	                        <option value='<?php echo $type["ID_TYPEACTIVITE"] ?>' <?php if(array_key_exists('types_activites', $_GET) && in_array($type["ID_TYPEACTIVITE"], (array) $_GET["types_activites"])) echo 'selected' ?>><?php echo $type["LIBELLE_TYPE"] . ' - ' . $type["LIBELLE_ACTIVITE"] ?></option>
@@ -93,13 +93,44 @@
                 </select>
             </span>
         </div>
+        
+        <div>
+            <select name='commissions[]' multiple onchange="masquerBoutonExportCalc()">
+                <?php foreach( $this->DB_commission as $commission ) : ?>
+                        <option value='<?php echo $commission["ID_COMMISSION"] ?>' <?php if(isset($_GET["commissions"]) && in_array($commission["ID_COMMISSION"], (array) $_GET["commissions"])) echo 'selected' ?>><?php echo $commission["LIBELLE_COMMISSION"] ?></option>
+                <?php endforeach ?>
+            </select>
+
+            <select name='groupements_territoriaux[]' multiple onchange="masquerBoutonExportCalc()">
+                <?php foreach( $this->DB_groupementterritorial as $groupement ) : ?>
+                	<?php $selected = false; ?>
+                    <?php if ($this->user['groupements'] != null): ?>
+                    	<?php foreach($this->user['groupements'] as $user_groupement): ?>
+                           	<?php if ($groupement['ID_GROUPEMENT'] == $user_groupement['ID_GROUPEMENT']): ?>
+                               	<?php $selected = true; ?>
+                                <?php break; ?>
+                            <?php endif ?>
+                        <?php endforeach ?>
+                    <?php endif ?>
+                	<option value='<?php echo $groupement["ID_GROUPEMENT"] ?>' <?php if((isset($_GET["groupements_territoriaux"]) && in_array($groupement["ID_GROUPEMENT"], (array) $_GET["groupements_territoriaux"])) || $selected) echo 'selected' ?>>
+                		<?php echo $groupement["LIBELLE_GROUPEMENT"] ?>
+                	</option>
+                <?php endforeach ?>
+            </select>
+        </div>
     </div>
-</form>
 
 <hr/>
 
 <?php if( count($this->results) > 0 ) : ?>
-    <p class='muted'><small>Nombre total d'éléments : <?php echo $this->results->getTotalItemCount() ?></small></p>
+    <div style='display:inline-block;width: 100%;' >
+    	<div class='pull-left'>
+    		<small>Nombre total d'éléments : <?php echo $this->results->getTotalItemCount() ?></small>
+    	</div>
+    	<div class='pull-right'>
+    		<input type='submit' class='btn btn-success' id='exporter' name='Exporter' value='Export Calc' <?php echo (($this->is_allowed_export_calc) ? '' : 'style="visibility: hidden;"') ?>>
+    	</div>
+    </div>
     <ul class='recherche_liste unstyled'>
     <?php echo $this->partialLoop('search/results/etablissement.phtml', $this->results ) ?>
     </ul>
@@ -110,6 +141,8 @@
 	<p class='muted'><small>Aucun résultat disponible.</small></p>
     <h2 style='color: silver; text-align: center;' ></h2>
 <?php endif ?>
+
+</form>
 
 <!-- Boite modale de la zone de recherche -->
 <form id='zone_de_recherche_modal' class="modal hide adresse">
@@ -123,13 +156,13 @@
         <dl class='dl-horizontal'>
             <dt>Ville</dt>
             <dd>
-                <input name='commune_ac' type='text' placeholder='Nom de la commune ou code postal ...' />
+                <input name='commune_ac' type='text' placeholder='Nom de la commune ou code postal ...'/>
                 <input name='code_insee' type='hidden' />
             </dd>
 
             <dt>Voie</dt>
             <dd>
-                <input type='text' name='voie_ac' placeholder='Nom de la voie ...' disabled />
+                <input type='text' name='voie_ac' placeholder='Nom de la voie ...' disabled/>
                 <input type='hidden' name='voie' />
             </dd>
         </dl>
@@ -137,7 +170,7 @@
 
     <div class="modal-footer">
         <a href="#" data-dismiss="modal" class="btn">Annuler</a>
-        <a class='submit btn btn-success' >Définir la zone de recherche</a>
+        <a class='submit btn btn-success' onclick="masquerBoutonExportCalc()" >Définir la zone de recherche</a>
     </div>
 </form>
 
@@ -158,6 +191,8 @@
 		$("select[name='types_activites[]']").multiselect({header: false, noneSelectedText: "Tous les types d'activités"});
 		$("select[name='avis[]']").multiselect({header: false, noneSelectedText: "Tous les avis"});
 		$("select[name='presences_local_sommeil[]']").multiselect({header: false, noneSelectedText: "Qu'importe la présence de local à sommeil", minWidth: 300});
+		$("select[name='commissions[]']").multiselect({header: false, noneSelectedText: "Toutes les commissions"});
+		$("select[name='groupements_territoriaux[]']").multiselect({header: false, noneSelectedText: "Tous les groupements territoriaux", minWidth: 300});
 
 		// Fonction d'affichage des critères en fonction du genre
 		function display_criteres_by_genres() {
@@ -261,4 +296,15 @@
             $('form#zone_de_recherche_modal').modal('hide');
         });
 	});
+
+    function masquerBoutonExportCalc ()
+    {
+    	document.getElementById('exporter').style.display = "none"
+    }
+
+    function afficherBoutonExportCalc ()
+    {
+    	document.getElementById('exporter').style.display = "inline"
+    }
+     
 </script>

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,24 @@
             "homepage": "https://github.com/SDIS62/prevarisc/contributors"
         }
     ],
+    
+    "repositories": [{
+	    "type": "package",
+	    "package": {
+	        "name": "PHPOffice/PHPExcel",
+	        "version": "1.8.1",
+	        "source": {
+	            "url": "https://github.com/PHPOffice/PHPExcel.git",
+	            "type": "git",
+	            "reference": "1.8.1"
+	        },
+	        "autoload": {
+	            "psr-0": {
+	                "PHPExcel": "Classes/"
+	            }
+	        }
+	    }
+	}],
 
     "require": {
         "php": "^5.5|^7.0",
@@ -25,7 +43,8 @@
         "kdubuc/gd_resize": "^1.0",
         "SDIS62/toolbox": "dev-master",
         "sebastian/git": "^1.0",
-        "sabre/vobject": "^4.0"
+        "sabre/vobject": "^4.0",
+        "PHPOffice/PHPExcel": "1.8.*"
     },
 
     "suggest": {

--- a/sql/migrations/2.5-34-export_calc.sql
+++ b/sql/migrations/2.5-34-export_calc.sql
@@ -1,0 +1,4 @@
+SET NAMES 'utf8';
+
+INSERT INTO `resources`(`id_resource`,`name`, `text`) VALUES(200,"export", "Export Calc");
+INSERT INTO `privileges`(`id_privilege`,`name`, `text`,`id_resource`) VALUES(200,"export_ets", "Etablissements",200);


### PR DESCRIPTION
- Utilisation de la librairie PHPOffice/PHPExcel
- Fonctionnalité régie par un nouveau droit (ajout ressource "Export
Calc" et privilège "Etablissements" dans la gestion des droits des
groupes)
- Si l'utilisateur connecté fait partie d'un groupe associé à ce droit,
un bouton "Export Calc" est visible sur l'écran de recherche des
établissements
- Ajout des filtres "Commission" et "Groupement territorial" sur cet
écran
- A l'arrivée sur cet écran, si l'utilisateur est associé à un
groupement territorial (type=5), la liste des établissements est
automatiquement filtrée sur ce groupement
- A chaque modification d'un filtre de recherche, on doit relancer la
recherche pour que le bouton "Export Calc" apparaisse (l'export
correspond donc aux filtres et à la liste affichés à l'écran)
- Penser à modifier le fichier php.ini pour des problématiques de
mémoire cache (augmenter les directives "max_execution_time" et
"memory_limit")

Change-Id: Ib12da9d9d9c3a310920c2efbbefb4cd430ff18a7