### PR TITLE
Connexion OpenLDAP

### DIFF
--- a/application/controllers/SessionController.php
+++ b/application/controllers/SessionController.php
@@ -66,7 +66,7 @@ class SessionController extends Zend_Controller_Action
 
                 // Adaptateur LDAP
                 if (getenv('PREVARISC_LDAP_ENABLED') == 1) {
-                    $ldap = new Zend_Ldap(array('host' => getenv('PREVARISC_LDAP_HOST'), 'port' => getenv('PREVARISC_LDAP_PORT') ? : 389, 'username' => getenv('PREVARISC_LDAP_USERNAME'), 'password' => getenv('PREVARISC_LDAP_PASSWORD'), 'baseDn' => getenv('PREVARISC_LDAP_BASEDN')));
+                    $ldap = new Zend_Ldap(array('host' => getenv('PREVARISC_LDAP_HOST'), 'port' => getenv('PREVARISC_LDAP_PORT') ? : 389, 'username' => getenv('PREVARISC_LDAP_USERNAME'), 'password' => getenv('PREVARISC_LDAP_PASSWORD'), 'baseDn' => getenv('PREVARISC_LDAP_BASEDN'), 'bindRequiresDn' => getenv('PREVARISC_LDAP_BIND_REQUIRES_DN')));
                     try {
                         $accountForm = getenv('PREVARISC_LDAP_ACCOUNT_FORM') ? getenv('PREVARISC_LDAP_ACCOUNT_FORM') : Zend_Ldap::ACCTNAME_FORM_DN;
                         $adapters['ldap'] = new Zend_Auth_Adapter_Ldap();


### PR DESCRIPTION
Ajout option "bindRequiresDn" dans l'adaptateur LDAP Zend pour permettre la connexion des utilisateurs via OpenLDAP.

Change-Id: If254396524370b8e625859ca5da957733fde629d