### PR TITLE
Correction de l'icone dropzone qui n'apparaissait plus au 2nd upload

### DIFF
--- a/application/views/scripts/piece-jointe/index.phtml
+++ b/application/views/scripts/piece-jointe/index.phtml
@@ -100,7 +100,7 @@
                         if (file.previewElement !== undefined) {
                             file.previewElement.remove();
                         }
-                        $('#dropzone').hide();
+                        $('#dropzone').removeClass("dz-started").hide();
                     } else
                     {
                         document.location.reload();


### PR DESCRIPTION
Correction de l'icone dropzone qui n'apparaissait plus au 2nd upload sur les pièces jointes dossier et calendrier des commissions