### PR TITLE
Correction de la non prise en compte du code postal lors de la géolocalisation IGN

### DIFF
--- a/application/views/scripts/etablissement/edit.phtml
+++ b/application/views/scripts/etablissement/edit.phtml
@@ -1020,7 +1020,7 @@
                 if (numero) {
                     adresse += numero + ", ";
                 }
-                adresse += voie + ", " + codepostal +  " " + commune;
+                adresse += voie + ", " + codepostal +  ", " + commune;
                 $("span.result").text("Géolocalisation en cours...");
 
                 geolocalizing = true;
@@ -1035,7 +1035,7 @@
             
 
         <?php endif ?>
-
+        
         // Géolocalisation de l'adresse
         $('#adresse-modal #geolocme_nominatim').click(function() {
             element = $(this);


### PR DESCRIPTION
La fonction de l'API IGN setCenterAtLocation découpe le paramètre adresse selon la virgule et prend l'avant dernier champ comme le code postale.
Celui-ci n'était pas pris en compte faisant baisser le niveau de précision de la géolocalisation.