### PR TITLE
Champ de compétence de la commission pour la création de dossiers

### DIFF
--- a/application/controllers/DossierController.php
+++ b/application/controllers/DossierController.php
@@ -703,8 +703,11 @@ class DossierController extends Zend_Controller_Action
         	$model_adresse = new Model_DbTable_EtablissementAdresse();
         	$array_adresses = $model_adresse->get($idEtablissement);
         	
-        	$service_dossier = new Service_Dossier();
-        	$this->view->default_commission = $service_dossier->getDefaultCommission($array_adresses[0]["NUMINSEE_COMMUNE"], $etablissement['ID_CATEGORIE'], $etablissement['ID_TYPE'], $etablissement['LOCALSOMMEIL_ETABLISSEMENTINFORMATIONS'], $idType);
+        	if(count($array_adresses) > 0) {
+        		$service_dossier = new Service_Dossier();
+        		$this->view->default_commission = $service_dossier->getDefaultCommission($array_adresses[0]["NUMINSEE_COMMUNE"], $etablissement['ID_CATEGORIE'], $etablissement['ID_TYPE'], $etablissement['LOCALSOMMEIL_ETABLISSEMENTINFORMATIONS'], $idType);
+        	}
+        	
         }
     }
     

--- a/application/models/DbTable/Commission.php
+++ b/application/models/DbTable/Commission.php
@@ -150,6 +150,61 @@
 
             }
         }
+        
+        public function getCommissionDossier($commune, $categorie, $type, $localsommeil, $etudevisite)
+        {
+        	// Check de la sous commission / comunale / interco / arrondissement
+        	// R�cup�ration des types de commission
+        	$model_types = new Model_DbTable_CommissionType;
+        	$array_typesCommission = $model_types->fetchAll(null, "ID_COMMISSIONTYPE DESC")->toArray();
+        
+        	foreach ($array_typesCommission as $row_typeCommission) {
+        
+        		$select = $this->select()
+        		->setIntegrityCheck(false)
+        		->from("commissionregle", array("ID_GROUPEMENT", "NUMINSEE_COMMUNE", "ID_COMMISSION") )
+        		->joinLeft("commission", "commission.ID_COMMISSION = commissionregle.ID_COMMISSION", null)
+        		->joinLeft("commissionregletype", "commissionregle.ID_REGLE = commissionregletype.ID_REGLE", null)
+        		->joinLeft("commissionreglecategorie", "commissionregle.ID_REGLE = commissionreglecategorie.ID_REGLE", null)
+        		->joinLeft("commissionreglelocalsommeil", "commissionregle.ID_REGLE = commissionreglelocalsommeil.ID_REGLE", null)
+        		->joinLeft("commissionregleetudevisite", "commissionregle.ID_REGLE = commissionregleetudevisite.ID_REGLE", null)
+        		->joinLeft("adressecommune", "adressecommune.NUMINSEE_COMMUNE = commissionregle.NUMINSEE_COMMUNE", null)
+        		->where("commissionreglecategorie.ID_CATEGORIE = ?", $categorie)
+        		->where("commissionregletype.ID_TYPE = ?", $type)
+        		->where("commissionreglelocalsommeil.LOCALSOMMEIL = ?", $localsommeil)
+        		->where("commissionregleetudevisite.ETUDEVISITE = ?", $etudevisite)
+        		->where("commission.ID_COMMISSIONTYPE = ?", $row_typeCommission["ID_COMMISSIONTYPE"]);
+        
+        		$results = $this->fetchAll($select);
+        
+        		if ($results != null) {
+        
+        			foreach($results as $result) {
+        
+        				if ($result->NUMINSEE_COMMUNE != null) {
+        					if ($result->NUMINSEE_COMMUNE == $commune) {
+        
+        						$result = $this->find( $result->ID_COMMISSION )->toArray();
+        
+        						return $result;
+        					}
+        				} elseif ($result->ID_GROUPEMENT) {
+        
+        					$model_groupementCommune = new Model_DbTable_GroupementCommune;
+        					$row_groupement = $model_groupementCommune->fetchRow("ID_GROUPEMENT = '" . $result->ID_GROUPEMENT . "' AND NUMINSEE_COMMUNE = '" . $commune . "'");
+        
+        					if (count($row_groupement) == 1) {
+        						$result = $this->find( $result->ID_COMMISSION )->toArray();
+        
+        						return $result;
+        					}
+        				}
+        			}
+        
+        		}
+        
+        	}
+        }
 
         public function getCommissionIGH( $commune, $classe, $localsommeil)
         {

--- a/application/services/Dossier.php
+++ b/application/services/Dossier.php
@@ -817,4 +817,31 @@ class Service_Dossier
        $dbDossier = new Model_DbTable_Dossier;
        return $dbDossier->getCommissionV2($idDossier);
     }
+    
+    /**
+     * Récupération de la commission par défaut en fonction des critères donnés pour un dossier et son établissement
+     *
+     * @param int $numinsee
+	 * @param int $categorie
+     * @param int $type
+     * @param bool $local_sommeil
+     * @param int $etudevisite
+     * @return array
+     */
+    public function getDefaultCommission($numinsee = null, $categorie = null, $type = null, $local_sommeil = null, $etudevisite = null)
+    {
+    	$model_etablissement = new Model_DbTable_Etablissement;
+    	$model_commission = new Model_DbTable_Commission;
+    	
+    	$defaultCommission = 0;
+    	
+    	if ($numinsee !== null && $categorie !== null && $type !== null && $local_sommeil !== null) {
+        	$commission = $model_commission->getCommissionDossier($numinsee, $categorie, $type, $local_sommeil ? 1 : 0, $etudevisite);
+            if($commission !== null) {
+            	$defaultCommission = $commission[0];
+       		}
+    	}
+    	
+    	return $defaultCommission;
+    }
 }

--- a/application/views/scripts/dossier/defaultcommission.phtml
+++ b/application/views/scripts/dossier/defaultcommission.phtml
@@ -1,0 +1,13 @@
+<?php
+echo "<input type='hidden' name='COMMISSION_DOSSIER' id='COMMISSION_DOSSIER' value='".(($this->default_commission["ID_COMMISSION"] != '') ? $this->default_commission["ID_COMMISSION"] : $this->infosDossier['COMMISSION_DOSSIER'])."' />";
+echo "<select name='commissionSelect' id='commissionSelect' >";
+	echo "<option value='0'>Aucune commission</option>";
+	foreach ($this->array_commissions as $array_commission) {
+    	echo "<optgroup label='".htmlspecialchars($array_commission["LIBELLE"], ENT_QUOTES)."' >";
+        foreach ($array_commission["ARRAY"] as $item) {
+        	echo "<option value='".$item["ID_COMMISSION"]."' ".(($this->default_commission["ID_COMMISSION"] != '' && $this->default_commission["ID_COMMISSION"] == $item["ID_COMMISSION"]) ? "selected" : "")." >".htmlspecialchars($item["LIBELLE_COMMISSION"]." (".$array_commission["LIBELLE"].")", ENT_QUOTES)."</option>";
+        }
+        echo "</optgroup>";
+	}
+	echo "</select>";
+?>

--- a/application/views/scripts/dossier/index.phtml
+++ b/application/views/scripts/dossier/index.phtml
@@ -194,6 +194,26 @@
 						return false;
 					}
 				});
+
+				if($("#do").val() == 'new'  && (idType == 1 || idType == 2 || idType == 3)){
+					$.ajax({
+						url: "/dossier/defaultcommission",
+						data: "idType="+idType+"&idEtablissement="+$("#idEtablissement").val(),
+						type:"POST",
+						beforeSend: function(){
+							$("#chargement").html("<img src='/images/load.gif' />");
+						},
+						success: function(affichageResultat){
+							$("#COMMISSION > .form").html(affichageResultat);
+							$("#COMMISSION").show();
+							$("#chargement").html("");
+							return false;
+						},
+						error: function(){
+							return false;
+						}
+					});
+				}
 				majAvisSelect();
 			}
 			return false;


### PR DESCRIPTION
 
Lors de la création d’un dossier de type « Étude » ou « Visite », il
faut vérifier s’il existe une règle applicable pour conseiller une
commission : c’est-à-dire si la combinaison des champs « N°
INSEE » (commune de l’adresse), « Catégorie », « Type » et « Local à
sommeil » de l’établissement, ainsi que le type du dossier correspondent
à une règle définie dans l’écran « Champ de la compétence de la
commission ». Cette vérification d’une commission compétente pour le
dossier à créer s’effectuera dans l’ordre suivant :
« Divers »
« Commission d’arrondissement »
« Commission intercommunale »
« Commission communale »
« Sous-commission départementale »
Dès lors que l’utilisateur a choisi le type et la nature du dossier, la
première commission compétente trouvée (pour laquelle une règle a été
définie et qui correspond aux informations du dossier en cours de
création) est présélectionnée, .

NB : Pour la mise en place de cette évolution, on considère qu’à la fois
les dossiers de type « Visite de commission » (ID_DOSSIERTYPE = 2) et
« Groupe de visite » (ID_DOSSIERTYPE = 3) correspondent à une « visite »
pour les règles de l’écran « Champ de la compétence de la commission ».

Change-Id: I7dab4de62d94e283cfa5e7d37b33df9727ced696