### PR TITLE
Correction #2199 Histotique avec date visite et non date commission

### DIFF
--- a/application/services/Etablissement.php
+++ b/application/services/Etablissement.php
@@ -355,7 +355,8 @@ class Service_Etablissement implements Service_Interface_Etablissement
           }
 
           if ( $value != null && (!isset( $historique[$key] ) || $tmp["valeur"] != $value )) {
-            $date = new Zend_Date($dossier->DATEVISITE_DOSSIER != null ? $dossier->DATEVISITE_DOSSIER : $dossier->DATECOMM_DOSSIER, Zend_Date::DATES);
+
+            $date = new Zend_Date($dossier->DATECOMM_DOSSIER != null ? $dossier->DATECOMM_DOSSIER : $dossier->DATEVISITE_DOSSIER, Zend_Date::DATES);
             if ($tmp != null) {
               $historique[$key][ count($historique[$key])-1 ]["fin"] = $date->get( Zend_Date::DAY_SHORT." ".Zend_Date::MONTH_NAME_SHORT." ".Zend_Date::YEAR );
             }


### PR DESCRIPTION
Lorsqu'un groupe de visite réalise une visite, il n'émet pas d'avis. Il propose un avis qui ne sera validé que lors du passage en commission.
La date d'avis reprise dans l'historique est celle de la date de visite et non pas la date de passage en commission du dossier, comme cela devrait être le cas réglementairement.
Modification du code pour afficher dans l'historique du changement d'avis la date de commission si elle existe et sinon la date de visite