### PR TITLE
Fixes #2216 Champs Facteur de criticite ds Levee de reserve

### DIFF
--- a/application/views/scripts/dossier/index.phtml
+++ b/application/views/scripts/dossier/index.phtml
@@ -861,6 +861,10 @@
 					}
 					$("#ANOMALIE").show();
 				}else if(type == 1){
+					if($("#selectNature").val() == 19 && $("#AVIS_DOSSIER_COMMISSION").val() == 2)
+					{
+						$("#FACTDANGE").show();
+					}
 					$("#ANOMALIE").show();
 				}
 
@@ -1038,6 +1042,14 @@
 			}else{
 				$("#FACTDANGE").hide();
 				$("#ECHEANCIERTRAV").hide();
+			}
+		}
+		if(type == 1 && $("#selectNature").val() == 19)
+		{
+			if($(this).val() == 2){
+				$("#FACTDANGE").show();
+			}else{
+				$("#FACTDANGE").hide();
 			}
 		}
 	});


### PR DESCRIPTION
Ajout du champs "Facteur de criticité" dans les dossiers de type "Levée de reserve" pour que le facteur de criticité ne soit pas écrasé lors d'une "Levée de reserve" qui resterait défavorable.