### PR TITLE
Lié à l'anomalie #2216 : Sélection du bon facteur de criticite 

### DIFF
--- a/application/views/scripts/dossier/index.phtml
+++ b/application/views/scripts/dossier/index.phtml
@@ -1698,11 +1698,11 @@ echo "
 					<div class='right form span9' ".(($action != 'new') ? "style='display:none;'" : "").">
 						<select name='FACTDANGE_DOSSIER' id='FACTDANGE_DOSSIER' >
 							<option value='0' >-</option>
-							<option value='1'>1</option>
-							<option value='2'>2</option>
+							<option value='1' ".((1 == $this->infosDossier['FACTDANGE_DOSSIER']) ? "selected='selected'" : "").">1</option>
+							<option value='2' ".((2 == $this->infosDossier['FACTDANGE_DOSSIER']) ? "selected='selected'" : "").">2</option>
 							<option value='3' ".((3 == $this->infosDossier['FACTDANGE_DOSSIER']) ? "selected='selected'" : "").">3</option>
-							<option value='4'>4</option>
-							<option value='5'>5</option>
+							<option value='4' ".((4 == $this->infosDossier['FACTDANGE_DOSSIER']) ? "selected='selected'" : "").">4</option>
+							<option value='5' ".((5 == $this->infosDossier['FACTDANGE_DOSSIER']) ? "selected='selected'" : "").">5</option>
 						</select>
 					</div>
 				</li>


### PR DESCRIPTION
Lors de la modification d'un dossier, le sélecteur "Facteur de criticité" n'était pas positionné sur le facteur présent en base.