### PR TITLE
Correction de l'autocompletion qui fonctionnait mal avec double quotes

### DIFF
--- a/application/layouts/includes/nav-main.phtml
+++ b/application/layouts/includes/nav-main.phtml
@@ -65,6 +65,7 @@
                 }
             },
             minChars: 3,
+            cacheLength: 0,
             width: 500,
             parse: function(data) {
                 return $.map(data["response"]["results"], function(row) {

--- a/application/views/scripts/commission/competences.phtml
+++ b/application/views/scripts/commission/competences.phtml
@@ -55,6 +55,7 @@
 	
 	$(".commune").autocomplete("/api/1.0/adresse/get_communes", {
             minChars: 3,
+            cacheLength: 0,
             parse: function(data) {
                 return $.map(data["response"], function(row) {return {data: row,value: row.LIBELLE_COMMUNE,result: row.LIBELLE_COMMUNE}});
             },

--- a/application/views/scripts/contact/index.phtml
+++ b/application/views/scripts/contact/index.phtml
@@ -178,6 +178,7 @@
 		
 		$("#nom_contact_existant").autocomplete("/contact/get?format=json", {
 			minChars: 3,
+                        cacheLength: 0,
 			max: 100,
 			parse: function(data) {
 				return $.map(data["resultats"], function(row) {

--- a/application/views/scripts/dossier/index.phtml
+++ b/application/views/scripts/dossier/index.phtml
@@ -50,6 +50,7 @@
 		// Auto complétion de la ville pour le service instructeur
         $("#servInstVille").autocomplete("/api/1.0/adresse/get_communes", {
             minChars: 3,
+            cacheLength: 0,
             parse: function(data) {
                 return $.map(data["response"], function(row) {return {data: row,value: row.LIBELLE_COMMUNE,result: row.LIBELLE_COMMUNE}});
             },

--- a/application/views/scripts/dossier/liees.phtml
+++ b/application/views/scripts/dossier/liees.phtml
@@ -227,6 +227,7 @@
                     return $("#saisieEtab").val();
                 }
             },
+            cacheLength: 0,
             minChars: 3,
             width: 500,
             parse: function(data) {

--- a/application/views/scripts/etablissement/edit.phtml
+++ b/application/views/scripts/etablissement/edit.phtml
@@ -886,6 +886,7 @@
         // Auto complétion de la ville
         $("input[name='commune_ac']").autocomplete("/api/1.0/adresse/get_communes", {
             minChars: 2,
+            cacheLength: 0,
             parse: function(data) {
                 return $.map(data["response"], function(row) {return {data: row,value: row.LIBELLE_COMMUNE,result: row.LIBELLE_COMMUNE}});
             },
@@ -905,6 +906,7 @@
         // Auto complétion de la rue
         $("input[name='voie_ac']").autocomplete('/api/1.0/adresse/get_voies', {
             minChars: 3,
+            cacheLength: 0,
             extraParams: { code_insee: function(){ return $("#adresse-modal input[name='code_insee']").val() } },
             parse: function(data) {
                 return $.map(data["response"], function(row) { return {data: row,value: row.LIBELLE_RUE,result: row.LIBELLE_RUE} });

--- a/application/views/scripts/search/etablissement.phtml
+++ b/application/views/scripts/search/etablissement.phtml
@@ -212,6 +212,7 @@
 		// Auto complétion de la ville
         $("form#zone_de_recherche_modal input[name='commune_ac']").autocomplete("/api/1.0/adresse/get_communes", {
             minChars: 3,
+            cacheLength: 0,
             parse: function(data) {
                 return $.map(data["response"], function(row) {return {data: row,value: row.LIBELLE_COMMUNE,result: row.LIBELLE_COMMUNE}});
             },
@@ -229,7 +230,12 @@
 
         // Auto complétion de la rue
         $("form#zone_de_recherche_modal input[name='voie_ac']").autocomplete('/api/1.0/adresse/get_voies', {
+<<<<<<< HEAD
             minChars: 3,
+=======
+            minChars: 2,
+            cacheLength: 0,
+>>>>>>> 7a90138... * Correction de l'autocompletion qui fonctionnait mal notamment lorsque le nom contient des doubles quotes
             extraParams: { code_insee: function(){ return $("input[name='code_insee']").val() } },
             parse: function(data) {
                 return $.map(data["response"], function(row) { return {data: row,value: row.LIBELLE_RUE,result: row.LIBELLE_RUE} });

--- a/application/views/scripts/search/etablissement.phtml
+++ b/application/views/scripts/search/etablissement.phtml
@@ -230,12 +230,8 @@
 
         // Auto complétion de la rue
         $("form#zone_de_recherche_modal input[name='voie_ac']").autocomplete('/api/1.0/adresse/get_voies', {
-<<<<<<< HEAD
             minChars: 3,
-=======
-            minChars: 2,
             cacheLength: 0,
->>>>>>> 7a90138... * Correction de l'autocompletion qui fonctionnait mal notamment lorsque le nom contient des doubles quotes
             extraParams: { code_insee: function(){ return $("input[name='code_insee']").val() } },
             parse: function(data) {
                 return $.map(data["response"], function(row) { return {data: row,value: row.LIBELLE_RUE,result: row.LIBELLE_RUE} });


### PR DESCRIPTION
Correction de l'autocompletion qui fonctionnait mal notamment lorsque le nom des établissements contient des doubles quotes.