### PR TITLE
Correction de messages d'erreur dans les logs en cas de suppression de pj

### DIFF
--- a/application/controllers/PieceJointeController.php
+++ b/application/controllers/PieceJointeController.php
@@ -281,7 +281,7 @@ class PieceJointeController extends Zend_Controller_Action
             }
 
             // On supprime dans la BDD et physiquement
-            if ($DBitem != null) {
+            if ($pj != null && $DBitem != null) {
                 
                 $file_path = $this->store->getFilePath($pj, $this->_request->type, $this->_request->id);
                 $miniature_pj = $pj;


### PR DESCRIPTION
Correction de messages d'erreur dans les logs en cas de suppression de piece jointe inexistante. C'est un cas rare.


